### PR TITLE
refactor: implement library/binary split with public API; add SIMD build flags

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "target-cpu=native"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,16 @@ categories = ["science", "command-line-utilities"]
 license-file = "LICENSE"
 exclude = ["bench/*", "data/*"]
 
+# Define the library target
+[lib]
+name = "deacon"
+path = "src/lib.rs"
+
+# Define the binary target
+[[bin]]
+name = "deacon"
+path = "src/main.rs"
+
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 flate2 = "1.1"
@@ -33,8 +43,6 @@ assert_cmd = "2.0"
 predicates = "3.0"
 tempfile = "3.8"
 rstest = "0.25"
-
-# No special target.cfg needed, dev-dependencies are available to unit tests
 
 # Define test files for organization
 [[test]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,4 @@ opt-level = 3
 lto = true
 codegen-units = 1
 panic = "abort"
+strip = true

--- a/README.md
+++ b/README.md
@@ -6,19 +6,15 @@ A fast minimizer-based filter for nucleotide sequences in FASTA or FASTQ format,
 
 The sensitivity/specificity/memory tradeoff can be tuned using *k*-mer length (`-k`), minimizer window length (`-w`), and match threshold (`-m`). With long reads, speeds of hundreds of megabases per second are possible by considering only the first `-n` bases of each query sequence. Uses [simd-minimizers](https://github.com/rust-seq/simd-minimizers) for fast vectorised minimizer calculation. This project is currently **unstable** and under active development.
 
-
-
 ## Install
 
 ### Cargo
+
 [![Crates.io](https://img.shields.io/crates/v/deacon.svg)](https://crates.io/crates/deacon)
 
-
-```
+```bash
 cargo install deacon
 ```
-
-
 
 ## Usage
 
@@ -31,13 +27,11 @@ deacon index build chm13v2.fa > human.k31w21.idx
 deacon index build -k 41 -m 27 chm13v2.fa > human.k41w27.idx  # Custom minimizer k and w
 ```
 
-
-
 ### Filtering
 
 Supports FASTA or FASTQ input from stdin or file and outputs to stdout or file. Paired sequences are supported as either separate files or interleaved stdin, and are  written in interleaved format to either stdout or file. Gzip (.gz) and Zstandard (.zst) compression formats are detected automatically. Piping uncompressed FASTA/Q to pigz is advisable in order to avoid compression bottlenecks when writing gzip output directly.
 
-``` bash
+```bash
 deacon filter human.idx reads.fq.gz -o filt.fastq  # File input & output
 zcat reads.fq.gz | deacon filter human.idx | pigz > filt.fq.gz  # Fast gzip
 zcat reads.fq.gz | deacon -n 1000 filter human.idx | pigz > filt.fq.gz  # Faster
@@ -47,8 +41,6 @@ deacon filter human.idx r1.fq.gz r2.fq.gz > filt12.fastq  # Paired file input
 zcat r12.fq.gz | deacon filter human.idx - - > filt12.fastq  # Interleaved stdin
 deacon filter human.idx reads.fq.gz --log log.json > filt.fq  # Log results JSON
 ```
-
-
 
 ## Reports
 
@@ -79,8 +71,6 @@ Use `--log results.json` to save filtering results to a JSON file:
   "bp_per_second": 43553881
 }
 ```
-
-
 
 ### Set operations on indexes
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -378,8 +378,8 @@ pub fn run<P: AsRef<Path>>(
         };
 
         // Write log file
-        let file = File::create(log_file)
-            .context(format!("Failed to create log file: {:?}", log_file))?;
+        let file =
+            File::create(log_file).context(format!("Failed to create log file: {:?}", log_file))?;
         let writer = BufWriter::new(file);
 
         // Serialize and write the log as JSON

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,213 @@
+//! # Deacon
+//!
+//! A fast minimizer-based filter for nucleotide sequences in FASTA or FASTQ format,
+//! built for efficient host depletion (*deacon*-tamination).
+//!
+//! This crate provides both a library and a binary for filtering nucleotide sequences.
+//!
+#![doc = include_str!("../README.md")]
+
+// Re-export public functionality
+pub mod filter;
+pub mod index;
+pub mod index_format;
+pub mod minimizers;
+
+// Keep these modules as internal implementation details
+mod index_build;
+mod index_diff;
+mod index_info;
+mod index_union;
+
+// Re-export the important structures and functions for library users
+pub use filter::{FilterLog, run as run_filter};
+pub use index::{
+    build as build_index, diff as diff_index, info as index_info, union as union_index,
+};
+pub use index_format::IndexHeader;
+pub use minimizers::{
+    DEFAULT_KMER_LENGTH, DEFAULT_WINDOW_SIZE, compute_minimizer_hashes, fill_minimizer_hashes,
+};
+
+use anyhow::Result;
+use rustc_hash::FxHashSet;
+use std::path::{Path, PathBuf};
+
+/// Configuration for filtering operations
+pub struct FilterConfig {
+    /// Minimizer index file path
+    pub minimizers_path: PathBuf,
+
+    /// Path to input fastx file (or - for stdin)
+    pub input_path: String,
+
+    /// Path to optional second paired fastx file (or - for interleaved stdin)
+    pub input2_path: Option<String>,
+
+    /// Path to output fastx file (or - for stdout; detects .gz and .zst)
+    pub output_path: String,
+
+    /// Minimum number of minimizer matches per query sequence (pair)
+    pub min_matches: usize,
+
+    /// Consider only the first N nucleotides per sequence (0 = entire sequence)
+    pub prefix_length: usize,
+
+    /// Path to JSON output log file
+    pub log_path: Option<PathBuf>,
+
+    /// Invert filtering (keep sequences WITH matches rather than those WITHOUT)
+    pub invert: bool,
+
+    /// Replace sequence headers with sequential numbers (1, 2, 3...)
+    pub rename: bool,
+}
+
+impl FilterConfig {
+    /// Create a new filtering configuration with the specified minimizers path
+    pub fn new<P: AsRef<Path>>(minimizers_path: P) -> Self {
+        Self {
+            minimizers_path: minimizers_path.as_ref().to_path_buf(),
+            input_path: "-".to_string(),
+            input2_path: None,
+            output_path: "-".to_string(),
+            min_matches: 2,
+            prefix_length: 0,
+            log_path: None,
+            invert: false,
+            rename: false,
+        }
+    }
+
+    /// Set the input path
+    pub fn with_input<S: Into<String>>(mut self, input_path: S) -> Self {
+        self.input_path = input_path.into();
+        self
+    }
+
+    /// Set the second input path for paired-end reads
+    pub fn with_input2<S: Into<String>>(mut self, input2_path: S) -> Self {
+        self.input2_path = Some(input2_path.into());
+        self
+    }
+
+    /// Set the output path
+    pub fn with_output<S: Into<String>>(mut self, output_path: S) -> Self {
+        self.output_path = output_path.into();
+        self
+    }
+
+    /// Set the minimum matches threshold
+    pub fn with_min_matches(mut self, min_matches: usize) -> Self {
+        self.min_matches = min_matches;
+        self
+    }
+
+    /// Set the prefix length
+    pub fn with_prefix_length(mut self, prefix_length: usize) -> Self {
+        self.prefix_length = prefix_length;
+        self
+    }
+
+    /// Set the log file path
+    pub fn with_log<P: AsRef<Path>>(mut self, log_path: P) -> Self {
+        self.log_path = Some(log_path.as_ref().to_path_buf());
+        self
+    }
+
+    /// Set the invert flag
+    pub fn with_invert(mut self, invert: bool) -> Self {
+        self.invert = invert;
+        self
+    }
+
+    /// Set the rename flag
+    pub fn with_rename(mut self, rename: bool) -> Self {
+        self.rename = rename;
+        self
+    }
+
+    /// Execute the filtering operation with this configuration
+    pub fn execute(&self) -> Result<()> {
+        filter::run(
+            &self.minimizers_path,
+            &self.input_path,
+            self.input2_path.as_deref(),
+            &self.output_path,
+            self.min_matches,
+            self.prefix_length,
+            self.log_path.as_ref(),
+            self.invert,
+            self.rename,
+        )
+    }
+}
+
+/// Configuration for index building operations
+pub struct IndexConfig {
+    /// Path to input fastx file
+    pub input_path: PathBuf,
+
+    /// K-mer length used for indexing
+    pub kmer_length: usize,
+
+    /// Minimizer window length used for indexing
+    pub window_length: usize,
+
+    /// Path to output file (None for stdout)
+    pub output_path: Option<PathBuf>,
+}
+
+impl IndexConfig {
+    /// Create a new index configuration with the specified input path
+    pub fn new<P: AsRef<Path>>(input_path: P) -> Self {
+        Self {
+            input_path: input_path.as_ref().to_path_buf(),
+            kmer_length: DEFAULT_KMER_LENGTH,
+            window_length: DEFAULT_WINDOW_SIZE,
+            output_path: None,
+        }
+    }
+
+    /// Set the k-mer length
+    pub fn with_kmer_length(mut self, kmer_length: usize) -> Self {
+        self.kmer_length = kmer_length;
+        self
+    }
+
+    /// Set the window length
+    pub fn with_window_length(mut self, window_length: usize) -> Self {
+        self.window_length = window_length;
+        self
+    }
+
+    /// Set the output path
+    pub fn with_output<P: AsRef<Path>>(mut self, output_path: P) -> Self {
+        self.output_path = Some(output_path.as_ref().to_path_buf());
+        self
+    }
+
+    /// Execute the index building operation with this configuration
+    pub fn execute(&self) -> Result<()> {
+        index_build::build(
+            &self.input_path,
+            self.kmer_length,
+            self.window_length,
+            self.output_path.clone(),
+        )
+    }
+}
+
+/// Load minimizer hashes from a file
+pub fn load_minimizers<P: AsRef<Path>>(path: P) -> Result<(FxHashSet<u64>, IndexHeader)> {
+    index::load_minimizer_hashes(&path)
+}
+
+/// Write minimizer hashes to a file
+pub fn write_minimizers(
+    minimizers: &FxHashSet<u64>,
+    header: &IndexHeader,
+    output_path: Option<&PathBuf>,
+) -> Result<()> {
+    index::write_minimizers(minimizers, header, output_path)
+}


### PR DESCRIPTION
- This should get you a docs page for the crate
- I noticed a build warning and put the cargo build config in at `.cargo/config.toml`:

```toml
rustflags = ["-C", "target-cpu=native"]
```

- added `strip = true` ([docs](https://doc.rust-lang.org/cargo/reference/profiles.html#strip)) to the Cargo release profile which should make your binaries smaller :-)

You might also want this in your Cargo.toml for faster (but larger!) builds when developing, I didn't add it:

```diff
[profile.dev]
opt-level = 0
lto = false
codegen-units = 256
panic = "abort"
debug = false
strip = "debuginfo"
```

- [x] cargo build passes
- [x] cargo test passes