### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,9 +556,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "mem_dbg"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83623b4167d3fbfb0f60eaa0cfd0f303a44e50f35a41b8d6bce87ad9d3e81410"
+checksum = "a3e3eb8a4c851185832fb250e5c041e74f4408e11fd56263cc1f61b48f9174f5"
 dependencies = [
  "bitflags",
  "mem_dbg-derive",
@@ -566,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "mem_dbg-derive"
-version = "0.1.7"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ac4642a5a1615ce3cdd3479f8d03c05068aab5a285a0722a24d5080d3f3e22"
+checksum = "f266c6ba1558dee16c56363c3dc6093a97a2451ddf29f928d5da042ee330537b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -634,9 +634,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "packed-seq"
-version = "1.0.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66357293f640400f7aaa7bfc9551476f4cdb0577dc3a7b9b7371a33be8e23581"
+checksum = "28884cb8a1678a01bd92eec6e39ef44537ebb30b53aceaab98f4931ee70b42bf"
 dependencies = [
  "cfg-if",
  "mem_dbg",
@@ -943,9 +943,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-minimizers"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21e3b5b1be74f7081349fa58f0370528543570896cb89fbf5e3a34f8434a65e"
+checksum = "f92df1a883c10e5d04b0cf137795aa3db1bb1a686f3cb5da9ff49440b8490062"
 dependencies = [
  "itertools",
  "packed-seq",
@@ -980,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/bede/deacon"
 homepage = "https://github.com/bede/deacon"
 keywords = ["bioinformatics", "genomics", "filtering", "decontamination"]
 categories = ["science", "command-line-utilities"]
-license  = "MIT"
+license = "MIT"
 exclude = ["bench/*", "data/*"]
 
 [lib]
@@ -20,8 +20,8 @@ clap = { version = "4.5", features = ["derive"] }
 flate2 = "1.1"
 anyhow = "1.0"
 thiserror = "2.0"
-simd-minimizers = "1.0.0"
-packed-seq = "1.0.2"
+simd-minimizers = "1.1"
+packed-seq = "2.0"
 rayon = "1"
 rustc-hash = "2.1.1"
 serde = { version = "1.0", features = ["derive"] }
@@ -35,7 +35,7 @@ indicatif = "0.17"
 [dev-dependencies]
 assert_cmd = "2.0"
 predicates = "3.0"
-tempfile = "3.8"
+tempfile = "3.20"
 rstest = "0.25"
 
 [[test]]


### PR DESCRIPTION
This PR updates dependencies to use `packed-seq` 2.0 and `simd-minimizers` 1.1 that we just released.