### PR TITLE
Add option to switch flate2 backend to zlib-rs via a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,9 @@ exclude = ["bench/*", "data/*"]
 name = "deacon"
 path = "src/lib.rs"
 
-[features]
-zlibrs = [ "flate2/zlib-rs"]
-
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
-flate2 = { version = "1.1", default-features = false }
+flate2 = { version = "1.1", features = ["zlib-rs"] }
 anyhow = "1.0"
 thiserror = "2.0"
 simd-minimizers = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,12 @@ exclude = ["bench/*", "data/*"]
 name = "deacon"
 path = "src/lib.rs"
 
+[features]
+zlibrs = [ "flate2/zlib-rs"]
+
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
-flate2 = "1.1"
+flate2 = { version = "1.1", default-features = false }
 anyhow = "1.0"
 thiserror = "2.0"
 simd-minimizers = "1.1"


### PR DESCRIPTION
Hi,

This adds the `zlibrs` feature for [compiling flate2 with the Rust zlib-rs backend](https://docs.rs/flate2#implementation) which is a bit faster than the default implementation.

In a benchmark using 69 million paired end reads (~5.5G files when compressed with DEFLATE) from a gut metagenome sample I get 40% increased throughput with zlib-rs:
```
## Default
[maklinto@r06c49 tmp]$ time deacon filter -d panhuman-1.k31w15.idx fwd_unfiltered.fastq.gz rev_unfiltered.fastq.gz -o fwd_filtered.fastq.gz -O rev_filtered.fastq.gz --threads 10
Deacon v0.5.0; mode: deplete; input: paired; options: match_threshold=2, threads=10
Loaded index (k=31, w=15) in 10.20s
Removed 73172/137483588 sequences (0.053%) , 10508351/19946761283 bp (0.053%)
Completed in 1121.90s. Speed: 122545 seqs/s (17.8 Mbp/s)

real    18m43.020s
user    37m28.028s
sys     0m14.579s

### With zlib-rs
[maklinto@r06c49 tmp]$ time deacon-zlib-rs filter -d panhuman-1.k31w15.idx fwd_unfiltered.fastq.gz rev_unfiltered.fastq.gz -o fwd_filtered.fastq.gz -O rev_filtered.fastq.gz --threads 10
Deacon v0.5.0; mode: deplete; input: paired; options: match_threshold=2, threads=10
Loaded index (k=31, w=15) in 10.06s
Removed 73172/137483588 sequences (0.053%) , 10508351/19946761283 bp (0.053%)
Completed in 791.79s. Speed: 173636 seqs/s (25.2 Mbp/s)

real    13m14.569s
user    33m57.170s
sys     0m12.392s
```

flate2 also supports using the C library [zlib-ng](https://github.com/zlib-ng/zlib-ng) as a backend which was slightly faster in my test case but this would introduce a compile time dependency on cmake and a C compiler so I don't think it's worth it. Here's the runtime with that:
```
## With zlib-ng
[maklinto@r06c49 tmp]$ time deacon-zlib-ng filter -d panhuman-1.k31w15.idx fwd_unfiltered.fastq.gz rev_unfiltered.fastq.gz -o fwd_filtered.fastq.gz -O rev_filtered.fastq.gz --threads 10
Deacon v0.5.0; mode: deplete; input: paired; options: match_threshold=2, threads=10
Loaded index (k=31, w=15) in 10.25s
Removed 73172/137483588 sequences (0.053%) , 10508351/19946761283 bp (0.053%)
Completed in 769.04s. Speed: 178774 seqs/s (25.9 Mbp/s)

real    12m54.241s
user    33m46.437s
sys     0m13.973s
```


It's probably safe to make zlib-rs the default but it uses some unsafe code so I opted to gate it behind a feature. Alternatively this could be flipped so that the default is to compile deacon with the zlibrs feature enabled and disabling default features reverts flate2 to safe-only.

Let me know if you want me to edit the PR accordingly.