### PR TITLE
Speed up short reads filtering by processing multiple records together

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -294,7 +294,7 @@ impl RecordBuffer {
 
         self.id_seq_ends.iter().map(move |&(id_end, seq_end)| {
             let rec = MinimalRecord {
-                id: &self.id_buffer[id_start..id_start],
+                id: &self.id_buffer[id_start..id_end],
                 seq: &self.seq_buffer[seq_start..seq_end],
                 qual: self
                     .qual_buffer


### PR DESCRIPTION
Hey @bede!

This PR aims to speed up short reads filtering by packing multiple records until we reach a length threshold (currently 8000 bp) and processing this batch with a single call to `simd_minimizers`. It introduces a `RecordBuffer` type that packs multiples sequences and headers in a single `Vec<u8>`, and uses this type internally in `FilterProcessor` to batch the operations. Currently, it is only implemented for the `ParallelProcessor` trait and isn't used for paired reads yet.

This might use a bit more copy than before since we have to keep some records longer (thus slightly slowing down long reads processing) but should bring a significant speedup for short reads.

Let me know if you're happy with the new performances and if you get consistent results with the previous implementation. If so, I can adapt the code to support paired reads as well.

Best,
Igor