### PR TITLE
128bit kmer values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,9 +709,9 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "packed-seq"
-version = "3.1.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a9babbc27830a3dc40ad5b56279156c87363cfe40e69d8ff93be1bcb2dbd9e"
+checksum = "7a308691a5bd3c1a4614c199859a9d0111002fa49df98a2bc3278d5e2da535f6"
 dependencies = [
  "cfg-if",
  "mem_dbg",
@@ -1071,9 +1071,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-minimizers"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797d91c61ae2e6ac0515d5929f5e9b26916ab8dc2d4844d10ec0d7270c2f522e"
+checksum = "71349df34ca49c733c43de5b02c5ea07a001353463013f56f16c19639ffdebd1"
 dependencies = [
  "itertools",
  "packed-seq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ clap = { version = "4.5", features = ["derive"] }
 flate2 = { version = "1.1", features = ["zlib-rs"] }
 anyhow = "1.0"
 thiserror = "2.0"
-simd-minimizers = "1.2"
+simd-minimizers = "1.3"
 packed-seq = "3.0"
 rayon = "1"
 rustc-hash = "2.1.1"

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -339,8 +339,8 @@ impl FilterProcessor {
         );
 
         assert!(
-            self.kmer_length <= 56,
-            "Indexing the bitmask of invalid characters requires k<=56, but it is {}",
+            self.kmer_length <= 57,
+            "Indexing the bitmask of invalid characters requires k<=57, but it is {}",
             self.kmer_length
         );
 
@@ -361,7 +361,7 @@ impl FilterProcessor {
 
         // Get hash values for valid positions
         minimizer_values.extend(
-            simd_minimizers::iter_canonical_minimizer_values(
+            simd_minimizers::iter_canonical_minimizer_values_u128(
                 packed_seq.as_slice(),
                 self.kmer_length as usize,
                 positions,

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,8 +89,8 @@ enum IndexCommands {
         /// Path to input fastx file (supports gz, zst and xz compression)
         input: PathBuf,
 
-        /// K-mer length used for indexing (1-32)
-        #[arg(short = 'k', default_value_t = DEFAULT_KMER_LENGTH, value_parser = clap::value_parser!(u8).range(1..=32))]
+        /// K-mer length used for indexing (1-57)
+        #[arg(short = 'k', default_value_t = DEFAULT_KMER_LENGTH, value_parser = clap::value_parser!(u8).range(1..=57))]
         kmer_length: u8,
 
         /// Minimizer window size used for indexing

--- a/src/minimizers.rs
+++ b/src/minimizers.rs
@@ -170,7 +170,7 @@ pub fn fill_minimizer_hashes(
         .collect();
 
     hashes.extend(
-        simd_minimizers::iter_canonical_minimizer_values(
+        simd_minimizers::iter_canonical_minimizer_values_u128(
             AsciiSeq(&canonical_seq),
             kmer_length as usize,
             &valid_positions,


### PR DESCRIPTION
This allows k up to 57.

Kmers are unconditionally read as `u128` values, then hashed from `u128` to `u64`, and then inserted into the hashmap.

On a small test with `fasta` input:
- baseline: 350 MB/s
- read u128, but hash as u64: 340 MB/s
- read u128, hash as u128: 336 MB/s

Note that hashing `0u64` and `0u128` gives different results (at least with xxhash), so this is an index-breaking change.
But anyway we may not want to do 128bit logic by default? Not sure -- the perf impact might just be small enough to always enable it and keep the API simple, but OTOH 4% gain is nice if all that is needed is to specify whether to use the u64 of u128 variant.

Fixes #35.

PS: the upper limit of 57 is because we want to do a single `u64` read form the N-indicator bitmask. For `k<=57`, these bits are guaranteed to be contained in a single byte-aligned `u64` read. For `k=58` we could have 1 bit + 7 bytes + 1 bit, which spans a total of 9 bytes.