### PR TITLE
Update to paraseq 0.4 for faster paired-end processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,17 +721,19 @@ dependencies = [
 
 [[package]]
 name = "paraseq"
-version = "0.3.9"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8edb6f120c1803e1199d2c5360443882ee9d7bacc7b41a0805c842c4db7590e2"
+checksum = "0b9266821364e175862f125d720ff295ed217de37dc6c8f47ca70ee7e122f161"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
+ "either",
+ "itertools",
  "memchr",
  "niffler",
  "parking_lot",
+ "smallvec",
  "thiserror 2.0.14",
- "tinyvec",
 ]
 
 [[package]]
@@ -1167,21 +1169,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml_datetime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0"
 bincode = { version = "2.0", features = ["serde"] }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 needletail = "0.6"
-paraseq = "0.3.9"
+paraseq = "0.4"
 niffler = "3"
 parking_lot = "0.12"
 zstd = "0.13"
@@ -63,4 +63,4 @@ lto = true
 codegen-units = 1
 panic = "abort"
 strip = false
-debug = false
+debug = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,12 @@ pub mod index;
 pub mod minimizers;
 
 // Re-export the important structures and functions for library users
-pub use filter::{FilterSummary, run as run_filter};
+pub use filter::{run as run_filter, FilterSummary};
 pub use index::{
-    IndexHeader, build as build_index, diff as diff_index, info as index_info, union as union_index,
+    build as build_index, diff as diff_index, info as index_info, union as union_index, IndexHeader,
 };
 pub use minimizers::{
-    DEFAULT_KMER_LENGTH, DEFAULT_WINDOW_SIZE, compute_minimizer_hashes, fill_minimizer_hashes,
+    compute_minimizer_hashes, fill_minimizer_hashes, DEFAULT_KMER_LENGTH, DEFAULT_WINDOW_SIZE,
 };
 
 use anyhow::Result;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use deacon::{
-    DEFAULT_KMER_LENGTH, DEFAULT_WINDOW_SIZE, FilterConfig, IndexConfig, diff_index, index_info,
-    union_index,
+    diff_index, index_info, union_index, FilterConfig, IndexConfig, DEFAULT_KMER_LENGTH,
+    DEFAULT_WINDOW_SIZE,
 };
 use std::path::PathBuf;
 


### PR DESCRIPTION
Paraseq 0.4 splits the input reading and unzipping over multiple threads, for up to 2x faster reading.

Running
```sh
cargo run -r -- filter -t 6 index-hg $d/rsviruses17900.r1.fastq.gz $d/rsviruses17900.r2.fastq.gz
```

before: 170 MB/s
after: 192 MB/s

This should be fully backwards compatible (both library API and index format), but please check.