### PR TITLE
[WIP] Update `simd-minimizers` to 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,9 +219,9 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "clap"
-version = "4.5.45"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.44"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.45"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -332,13 +332,14 @@ dependencies = [
  "liblzma",
  "needletail",
  "niffler",
- "packed-seq",
+ "packed-seq 4.0.0",
  "paraseq",
  "parking_lot",
  "predicates",
  "rayon",
  "rstest",
  "rustc-hash",
+ "seq-hash 0.0.1",
  "serde",
  "serde_json",
  "simd-minimizers",
@@ -709,9 +710,19 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "packed-seq"
-version = "3.2.1"
+version = "4.0.0"
+dependencies = [
+ "cfg-if",
+ "mem_dbg",
+ "rand",
+ "wide",
+]
+
+[[package]]
+name = "packed-seq"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a308691a5bd3c1a4614c199859a9d0111002fa49df98a2bc3278d5e2da535f6"
+checksum = "5958f4aaa8afc3f0ac843427539bc2e104ed5cfc277c220cc627d7fb7551c3d3"
 dependencies = [
  "cfg-if",
  "mem_dbg",
@@ -1034,6 +1045,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
+name = "seq-hash"
+version = "0.0.1"
+dependencies = [
+ "packed-seq 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wide",
+]
+
+[[package]]
+name = "seq-hash"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b7db377400415bb83f24f52281d07b988cf93fe9b69304609aa682a17f2b8"
+dependencies = [
+ "packed-seq 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wide",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,12 +1102,12 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-minimizers"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71349df34ca49c733c43de5b02c5ea07a001353463013f56f16c19639ffdebd1"
+version = "2.0.1"
 dependencies = [
+ "clap",
  "itertools",
- "packed-seq",
+ "packed-seq 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seq-hash 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wide",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,9 @@ clap = { version = "4.5", features = ["derive"] }
 flate2 = { version = "1.1", features = ["zlib-rs"] }
 anyhow = "1.0"
 thiserror = "2.0"
-simd-minimizers = "1.3"
-packed-seq = "3.0"
+simd-minimizers.path = "../../simd-minimizers"
+packed-seq.path = "../../packed-seq"
+seq-hash.path = "../../seq-hash"
 rayon = "1"
 rustc-hash = "2.1.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,4 +1,5 @@
 use crate::IndexConfig;
+use crate::minimizers::KmerHasher;
 use anyhow::{Context, Result};
 use bincode::serde::{decode_from_std_read, encode_into_std_write};
 use rayon::prelude::*;
@@ -195,6 +196,8 @@ pub fn build(config: &IndexConfig) -> Result<()> {
     // Process sequences in batches for parallelization
     let batch_size = 10000;
 
+    let hasher = KmerHasher::new(config.kmer_length as usize);
+
     loop {
         // Collect a batch of sequences
         let mut batch = Vec::with_capacity(batch_size);
@@ -227,6 +230,7 @@ pub fn build(config: &IndexConfig) -> Result<()> {
                 // Compute minimizer hashes for this sequence
                 crate::minimizers::compute_minimizer_hashes(
                     seq_data,
+                    &hasher,
                     config.kmer_length,
                     config.window_size,
                     config.entropy_threshold,
@@ -326,6 +330,8 @@ fn stream_diff_fastx<P: AsRef<Path>>(
     // Process sequences in batches for parallelization
     let batch_size = 1000;
 
+    let hasher = KmerHasher::new(kmer_length as usize);
+
     loop {
         // Collect a batch of sequences
         let mut batch = Vec::with_capacity(batch_size);
@@ -356,7 +362,13 @@ fn stream_diff_fastx<P: AsRef<Path>>(
             .par_iter()
             .map(|(seq_data, _id)| {
                 // Compute minimizer hashes for this sequence
-                crate::minimizers::compute_minimizer_hashes(seq_data, kmer_length, window_size, 0.0)
+                crate::minimizers::compute_minimizer_hashes(
+                    seq_data,
+                    &hasher,
+                    kmer_length,
+                    window_size,
+                    0.0,
+                )
             })
             .collect();
 

--- a/src/minimizers.rs
+++ b/src/minimizers.rs
@@ -6,21 +6,6 @@ pub const DEFAULT_WINDOW_SIZE: u8 = 15;
 /// Canonical NtHash, with 1-bit rotations for backwards compatibility.
 pub type KmerHasher = seq_hash::NtHasher<true, 1>;
 
-/// Check if nucleotide is valid ACGT (case insensitive)
-#[inline]
-fn is_valid_acgt(nucleotide: u8) -> bool {
-    matches!(
-        nucleotide,
-        b'A' | b'C' | b'G' | b'T' | b'a' | b'c' | b'g' | b't'
-    )
-}
-
-/// Check if k-mer contains only ACGT nucleotides
-#[inline]
-fn kmer_contains_only_acgt(kmer: &[u8]) -> bool {
-    kmer.iter().all(|&b| is_valid_acgt(b))
-}
-
 /// Canonicalise IUPAC ambiguous nucleotides to ACGT
 #[inline]
 fn canonicalise_nucleotide(nucleotide: u8) -> u8 {


### PR DESCRIPTION
`simd-minimizers` 2.0 is up to 2x faster for short (150bp) reads by avoiding repeated allocations.

This change should also be fully backwards compatible; it explicitly uses `NtHasher<CANONICAL=true, R=1>` which corresponds to the previous default, but also here: please check.

WIP because I haven't release the last simd-minimizers yet; but wanted to push this already :)

Running
```sh
cargo run -r -- filter -t 6 index-hg $d/rsviruses17900.r1.fastq.gz $d/rsviruses17900.r2.fastq.gz
```
before (with paraseq 0.4): 192 MB/s
after: 260 MB/s