### PR TITLE
Small socket server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,11 @@ predicates = "3.0"
 tempfile = "3.20"
 rstest = "0.25"
 
+[features]
+# `deacon server` feature.
+server = []
+default = []
+
 [[test]]
 name = "cli_tests"
 path = "tests/cli_tests.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ rstest = "0.25"
 [features]
 # `deacon server` feature.
 server = []
-default = []
+default = ["server"]
 
 [[test]]
 name = "cli_tests"

--- a/src/index.rs
+++ b/src/index.rs
@@ -79,7 +79,11 @@ pub fn load_minimizer_hashes_cached<P: AsRef<Path>>(
         let (m, h) = load_minimizer_hashes(path).unwrap();
         (path.as_ref().to_owned(), m, h)
     });
-    assert_eq!(p, path.as_ref(), "Currently, the server can only have one index loaded.");
+    assert_eq!(
+        p,
+        path.as_ref(),
+        "Currently, the server can only have one index loaded."
+    );
 
     Ok((minimizers, header))
 }


### PR DESCRIPTION
Inspired by #41, but more minimalistic, this add a small `deacon server` mode that opens a unix socket in its working directory.

Then running more commands like `deacond --use-server filter ...` will forward all arguments to the server, which will process them.

Does not support networking, nor stdin/stdout (TODO add some checks for this?), since all IO is done by the server.

As said before, main benefit here is that you don't have to wait for the index to load on each invocation.

Limitations:
- you'll have to clean up the `deacon_server_socket` file manually between runs
- for now each server only supports a single index. Should be fine anyway.

Maybe we should restrict the commands sent to the server to only `Filter`? All index construction/modification commands aren't cached anyway.

TODO: pass the `-t THREADS` flag to the server invocation and use that instead of whatever the first client passed.