### PR TITLE
Index v3: fixed width integer encoding

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
+use deacon::index::convert_index;
 use deacon::{
     DEFAULT_KMER_LENGTH, DEFAULT_WINDOW_SIZE, FilterConfig, IndexConfig, diff_index, index_info,
     union_index,
@@ -169,6 +170,11 @@ enum IndexCommands {
         #[arg(short = 'o', long = "output", default_value = "-")]
         output: Option<PathBuf>,
     },
+    Convert {
+        /// Path to index file
+        from: PathBuf,
+        to: PathBuf,
+    },
 }
 
 #[cfg(feature = "server")]
@@ -307,6 +313,9 @@ fn process_command(command: &Commands) -> Result<(), anyhow::Error> {
             } => {
                 diff_index(first, second, *kmer_length, *window_size, output.as_ref())
                     .context("Failed to run index diff command")?;
+            }
+            IndexCommands::Convert { from, to } => {
+                convert_index(from, to)?;
             }
         },
         Commands::Filter {


### PR DESCRIPTION
- new index format that used fixed 8 byte encoding
- `deacon convert` to convert from v2 to v3 (might need some extra docs)
- read the fixed-width ints manually instead of through `bincode`.