### PR TITLE
Consistently use `get_minimizer_positions_and_hashes`

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -389,20 +389,8 @@ impl FilterProcessor {
     }
 
     fn get_minimizer_hashes_and_positions(&self, seq: &[u8]) -> (Vec<u64>, Vec<u32>) {
-        // Canonicalise sequence
-        let canonical_seq = seq
-            .iter()
-            .map(|&b| match b {
-                b'A' | b'a' => b'A',
-                b'C' | b'c' => b'C',
-                b'G' | b'g' => b'G',
-                b'T' | b't' => b'T',
-                _ => b'C',
-            })
-            .collect::<Vec<u8>>();
-
         let mut positions = Vec::new();
-        let packed_seq = packed_seq::PackedSeqVec::from_ascii(&canonical_seq);
+        let packed_seq = packed_seq::PackedSeqVec::from_ascii(seq);
         let out = simd_minimizers::canonical_minimizers(
             self.kmer_length as usize,
             self.window_size as usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,9 +17,7 @@ pub use filter::{FilterSummary, run as run_filter};
 pub use index::{
     IndexHeader, build as build_index, diff as diff_index, info as index_info, union as union_index,
 };
-pub use minimizers::{
-    DEFAULT_KMER_LENGTH, DEFAULT_WINDOW_SIZE, compute_minimizer_hashes, fill_minimizer_hashes,
-};
+pub use minimizers::{DEFAULT_KMER_LENGTH, DEFAULT_WINDOW_SIZE, compute_minimizer_hashes};
 
 use anyhow::Result;
 use rustc_hash::FxHashSet;


### PR DESCRIPTION
- Drop old canonicalisation; now we completely skip windows containing non-ACTG instead.
- Remove previous manual `ACTG` checks.
- Use `get_minimizer_positions_and_hashes` whereever possible, in particular in `should_keep_sequence`, `should_keep_pair`, and two functions in `index.rs`.
- Also simplify `should_keep_pair` to be more like `should_keep_sequence`


This increases paired-end short-read fasta throughput from 355 MB/s to 632 MB/s (by reusing allocations and by applying `skip_ambiguous_windows` there)