### PR TITLE
New flat hashset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,7 @@ dependencies = [
  "simd-minimizers",
  "tempfile",
  "thiserror 2.0.16",
+ "wide",
  "xxhash-rust",
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ parking_lot = "0.12"
 zstd = "0.13"
 indicatif = "0.17"
 liblzma = "0.3.1"
+wide = "0.7.33"
 
 [lints.clippy]
 too_many_arguments = "allow"

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -16,6 +16,7 @@ use std::fs::{File, OpenOptions};
 use std::io::{self, BufWriter, Write};
 use std::sync::Arc;
 use std::time::Instant;
+use crate::HashSet;
 use xxhash_rust;
 use zstd::stream::write::Encoder as ZstdEncoder;
 
@@ -212,7 +213,7 @@ pub struct FilterSummary {
 #[derive(Clone)]
 struct FilterProcessor {
     // Minimizer matching parameters
-    minimizer_hashes: &'static FxHashSet<u64>,
+    minimizer_hashes: &'static HashSet,
     kmer_length: u8,
     window_size: u8,
     abs_threshold: usize,
@@ -278,7 +279,7 @@ impl FilterProcessor {
         }
     }
     fn new(
-        minimizer_hashes: &'static FxHashSet<u64>,
+        minimizer_hashes: &'static HashSet,
         kmer_length: u8,
         window_size: u8,
         config: &FilterProcessorConfig,
@@ -369,7 +370,7 @@ impl FilterProcessor {
         let mut hit_kmers = Vec::new();
 
         for (i, &hash) in minimizer_values.iter().enumerate() {
-            if self.minimizer_hashes.contains(&hash) && seen_hits.insert(hash) {
+            if self.minimizer_hashes.contains(hash) && seen_hits.insert(hash) {
                 hit_count += 1;
                 // Extract the k-mer sequence at this position
                 if self.debug && i < positions.len() {
@@ -469,7 +470,7 @@ impl FilterProcessor {
 
         // Count hits and collect k-mers
         for (i, &hash) in all_hashes.iter().enumerate() {
-            if self.minimizer_hashes.contains(&hash) && seen_hits_pair.insert(hash) {
+            if self.minimizer_hashes.contains(hash) && seen_hits_pair.insert(hash) {
                 pair_hit_count += 1;
                 if self.debug && i < all_positions.len() && i < all_sequences.len() {
                     let pos = all_positions[i] as usize;

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,4 +1,5 @@
 use crate::FilterConfig;
+use crate::HashSet;
 use crate::index::load_minimizer_hashes_cached;
 use crate::minimizers::KmerHasher;
 use anyhow::{Context, Result};
@@ -16,7 +17,6 @@ use std::fs::{File, OpenOptions};
 use std::io::{self, BufWriter, Write};
 use std::sync::Arc;
 use std::time::Instant;
-use crate::HashSet;
 use xxhash_rust;
 use zstd::stream::write::Encoder as ZstdEncoder;
 

--- a/src/hashset.rs
+++ b/src/hashset.rs
@@ -17,21 +17,6 @@ pub struct U64HashSet {
     has_zero: bool,
 }
 
-impl IntoIterator for &U64HashSet {
-    type Item = u64;
-
-    type IntoIter = impl Iterator<Item = u64>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        std::iter::repeat_n(0, self.has_zero as usize).chain(
-            self.table
-                .iter()
-                .flat_map(|b| b.0.iter().copied())
-                .filter(|x| *x != 0),
-        )
-    }
-}
-
 const BUCKET_SIZE: usize = 8;
 
 #[derive(Clone, Copy)]
@@ -53,6 +38,15 @@ impl U64HashSet {
     #[inline(always)]
     pub fn len(&self) -> usize {
         self.len + self.has_zero as usize
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = u64>{
+        std::iter::repeat_n(0, self.has_zero as usize).chain(
+            self.table
+                .iter()
+                .flat_map(|b| b.0.iter().copied())
+                .filter(|x| *x != 0),
+        )
     }
 
     #[inline(always)]

--- a/src/hashset.rs
+++ b/src/hashset.rs
@@ -1,0 +1,131 @@
+//! A dense_hash_set for u64 keys.
+//!
+//! Compared to std::collections::HashSet<u64>, this uses a different layout: no metadata table, just plain data.
+//! This is similar to Google's dense_hash_map, which predates the SwissTable design. By avoiding a metadata table,
+//! we may need to do longer probe sequences (each probe is 8 bytes, not 1 byte), but on the other hand we only take
+//! 1 cache miss per access, not 2.
+
+use std::hash::{BuildHasher, BuildHasherDefault};
+
+use wide::CmpEq;
+
+type Hasher = BuildHasherDefault<rustc_hash::FxHasher>;
+
+pub struct U64HashSet {
+    table: Box<[Bucket]>,
+    len: usize,
+    has_zero: bool,
+}
+
+impl IntoIterator for &U64HashSet {
+    type Item = u64;
+
+    type IntoIter = impl Iterator<Item = u64>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        std::iter::repeat_n(0, self.has_zero as usize).chain(
+            self.table
+                .iter()
+                .flat_map(|b| b.0.iter().copied())
+                .filter(|x| *x != 0),
+        )
+    }
+}
+
+const BUCKET_SIZE: usize = 8;
+
+#[derive(Clone, Copy)]
+#[repr(align(64))] // Cache line alignment
+struct Bucket([u64; BUCKET_SIZE]);
+
+impl U64HashSet {
+    pub fn with_capacity(capacity: usize) -> Self {
+        // TODO: integer overflow...
+        let num_buckets = (capacity.next_power_of_two() * 2).div_ceil(BUCKET_SIZE);
+        let table = vec![Bucket([0u64; BUCKET_SIZE]); num_buckets].into_boxed_slice();
+        Self {
+            table,
+            len: 0,
+            has_zero: false,
+        }
+    }
+
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.len + self.has_zero as usize
+    }
+
+    #[inline(always)]
+    pub fn prefetch(&self, key: u64) {
+        let hash64 = Hasher::default().hash_one(key);
+        let bucket_mask = self.table.len() - 1;
+        let bucket_i = hash64 as usize;
+        // Safety: bucket_mask is correct because the number of buckets is a power of 2.
+        unsafe {
+            std::intrinsics::prefetch_write_data::<_, 0>(
+                self.table.get_unchecked(bucket_i & bucket_mask) as *const Bucket as *const u8,
+            )
+        };
+    }
+
+    #[inline(always)]
+    pub fn contains(&self, key: u64) -> bool {
+        if key == 0 {
+            return self.has_zero;
+        }
+        let hash64 = Hasher::default().hash_one(key);
+        let bucket_mask = self.table.len() - 1;
+        let mut bucket_i = hash64 as usize;
+
+        // type S = wide::u64x4;
+        type S = wide::i64x4;
+        let keys = S::splat(key as i64);
+
+        loop {
+            use std::mem::transmute;
+            // Safety: bucket_mask is correct because the number of buckets is a power of 2.
+            let bucket = unsafe { self.table.get_unchecked(bucket_i & bucket_mask) };
+            let [h1, h2]: &[S; 2] = unsafe { transmute(&bucket.0) };
+            let mask = (h1.cmp_eq(keys) | h2.cmp_eq(keys)).move_mask() as u8;
+            if mask > 0 {
+                return true;
+            }
+            let has_zero = (h1.cmp_eq(S::ZERO) | h2.cmp_eq(S::ZERO)).move_mask() as u8;
+            if has_zero > 0 {
+                return false;
+            }
+
+            bucket_i += 1;
+        }
+    }
+
+    #[inline(always)]
+    pub fn insert(&mut self, key: u64) {
+        if key == 0 {
+            self.len += !self.has_zero as usize;
+            self.has_zero = true;
+            return;
+        }
+        let hash64 = Hasher::default().hash_one(key);
+        let bucket_mask = self.table.len() - 1;
+        let element_offset_in_bucket = (hash64 >> 61) as usize;
+        let mut bucket_i = hash64 as usize;
+
+        loop {
+            // Safety: bucket_mask is correct because the number of buckets is a power of 2.
+            let bucket = unsafe { self.table.get_unchecked_mut(bucket_i & bucket_mask) };
+            for element_i in 0..BUCKET_SIZE {
+                let element = &mut bucket.0[(element_i + element_offset_in_bucket) % BUCKET_SIZE];
+                if *element == 0 {
+                    *element = key;
+                    self.len += 1;
+                    return;
+                }
+                if *element == key {
+                    return;
+                }
+            }
+            bucket_i += 1;
+        }
+    }
+}

--- a/src/hashset.rs
+++ b/src/hashset.rs
@@ -5,31 +5,57 @@
 //! we may need to do longer probe sequences (each probe is 8 bytes, not 1 byte), but on the other hand we only take
 //! 1 cache miss per access, not 2.
 
-use std::hash::{BuildHasher, BuildHasherDefault};
+use std::arch::x86_64::{_mm_prefetch, _MM_HINT_T0};
+use std::hint::select_unpredictable;
+use std::mem::transmute;
+type S = wide::i64x4;
 
+use rustc_hash::FxHashMap;
 use wide::CmpEq;
 
+fn mul_high(a: u64, b: usize) -> usize {
+    ((a as u128) * (b as u128) >> 64) as usize
+}
+
 pub struct U64HashSet {
+    buckets: usize,
     table: Box<[Bucket]>,
     len: usize,
     has_zero: bool,
+    hits: usize,
+    skips: usize,
+    skips2: usize,
+    last_b: usize,
+    last_j: usize,
+    last_key: u64,
 }
+
+const PADDING: usize = 1000;
 
 const BUCKET_SIZE: usize = 8;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(align(64))] // Cache line alignment
 struct Bucket([u64; BUCKET_SIZE]);
 
 impl U64HashSet {
-    pub fn with_capacity(capacity: usize) -> Self {
-        // TODO: integer overflow...
-        let num_buckets = (capacity.next_power_of_two() * 2).div_ceil(BUCKET_SIZE);
-        let table = vec![Bucket([0u64; BUCKET_SIZE]); num_buckets].into_boxed_slice();
+    pub fn with_capacity(n: usize) -> Self {
+        eprintln!("N        {n:>10}");
+        let capacity = n * 15 / 10;
+        eprintln!("CAPACITY {capacity:>10}");
+        let buckets = capacity.div_ceil(BUCKET_SIZE);
+        let table = vec![Bucket([0u64; BUCKET_SIZE]); buckets + PADDING].into_boxed_slice();
         Self {
+            buckets,
             table,
             len: 0,
             has_zero: false,
+            hits: 0,
+            skips: 0,
+            skips2: 0,
+            last_b: 0,
+            last_j: 0,
+            last_key: 0,
         }
     }
 
@@ -38,7 +64,7 @@ impl U64HashSet {
         self.len + self.has_zero as usize
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = u64>{
+    pub fn iter(&self) -> impl Iterator<Item = u64> {
         std::iter::repeat_n(0, self.has_zero as usize).chain(
             self.table
                 .iter()
@@ -47,14 +73,76 @@ impl U64HashSet {
         )
     }
 
+    pub fn test(&self) {
+        for x in self.iter() {
+            if !self.contains(x) {
+                eprintln!("Did not find {x}!");
+                let hash64 = x;
+                let bucket_i = mul_high(hash64, self.buckets);
+
+                let [h1, h2]: &[S; 2] = unsafe { transmute(&self.table[bucket_i]) };
+                let c0 = h1.cmp_eq(S::ZERO).move_mask().count_ones() as usize;
+                let c1 = h2.cmp_eq(S::ZERO).move_mask().count_ones() as usize;
+                let elems = BUCKET_SIZE - c0 - c1;
+                eprintln!("Intended bucket {bucket_i} of size {elems}");
+                let flat = unsafe { self.table.align_to::<u64>().1 };
+                let pos = flat.iter().position(|y| *y == x);
+                eprintln!("Found at {pos:?}");
+                if let Some(p) = pos {
+                    let bucket = p / BUCKET_SIZE;
+                    eprintln!("Actual bucket {bucket}");
+                }
+
+                panic!();
+            }
+        }
+    }
+
+    pub fn stats(&self) {
+        let mut counts = [0; 9];
+
+        eprintln!("Size    : {}", self.len);
+        eprintln!("hits    : {}", self.hits);
+        eprintln!("Skips   : {}", self.skips);
+        eprintln!("Skips/el: {}", self.skips as f32 / self.hits as f32);
+        eprintln!("Skips2/el {}", self.skips2 as f32 / self.hits as f32);
+        // return;
+
+        let mut sum = 0;
+        let mut cnt = 0;
+        for bucket in &self.table {
+            let [h1, h2]: &[S; 2] = unsafe { transmute(&bucket.0) };
+            let c0 = h1.cmp_eq(S::ZERO).move_mask().count_ones() as usize;
+            let c1 = h2.cmp_eq(S::ZERO).move_mask().count_ones() as usize;
+            let elems = BUCKET_SIZE - c0 - c1;
+            counts[elems] += 1;
+            cnt += 1;
+            sum += elems;
+        }
+        for i in 0..=8 {
+            eprintln!("{i}: {:>9}", counts[i]);
+        }
+        eprintln!("buckets {cnt}");
+        eprintln!("slots   {}", cnt * BUCKET_SIZE);
+        eprintln!("sum {sum}");
+        eprintln!("avg {}", sum as f32 / cnt as f32);
+
+        self.test();
+    }
+
+    #[inline(always)]
+    fn bucket_idx(&self, key: u64) -> usize {
+        mul_high(key, self.buckets)
+    }
+
     #[inline(always)]
     pub fn prefetch(&self, key: u64) {
-        let bucket_mask = self.table.len() - 1;
-        let bucket_i = key as usize;
+        let hash64 = key;
+        let bucket_i = self.bucket_idx(hash64);
         // Safety: bucket_mask is correct because the number of buckets is a power of 2.
         unsafe {
-            std::intrinsics::prefetch_write_data::<_, 0>(
-                self.table.get_unchecked(bucket_i & bucket_mask) as *const Bucket as *const u8,
+            _mm_prefetch::<_MM_HINT_T0>(
+                self.table.get_unchecked(bucket_i) as *const Bucket as *const i8
             )
         };
     }
@@ -64,8 +152,8 @@ impl U64HashSet {
         if key == 0 {
             return self.has_zero;
         }
-        let bucket_mask = self.table.len() - 1;
-        let mut bucket_i = key as usize;
+        let hash64 = key;
+        let mut bucket_i = self.bucket_idx(hash64);
 
         // type S = wide::u64x4;
         type S = wide::i64x4;
@@ -74,7 +162,7 @@ impl U64HashSet {
         loop {
             use std::mem::transmute;
             // Safety: bucket_mask is correct because the number of buckets is a power of 2.
-            let bucket = unsafe { self.table.get_unchecked(bucket_i & bucket_mask) };
+            let bucket = unsafe { self.table.get_unchecked(bucket_i) };
             let [h1, h2]: &[S; 2] = unsafe { transmute(&bucket.0) };
             let mask = (h1.cmp_eq(keys) | h2.cmp_eq(keys)).move_mask() as u8;
             if mask > 0 {
@@ -90,31 +178,77 @@ impl U64HashSet {
     }
 
     #[inline(always)]
-    pub fn insert(&mut self, key: u64) {
+    pub fn insert(&mut self, key: u64) -> bool {
         if key == 0 {
             self.len += !self.has_zero as usize;
+            let ret = !self.has_zero;
+            self.has_zero = true;
+            return ret;
+        }
+        let hash64 = key;
+        let mut bucket_i = self.bucket_idx(hash64);
+        let keys = S::splat(key as i64);
+
+        let mut i = 0;
+        loop {
+            // Safety: bucket_mask is correct because the number of buckets is a power of 2.
+            let bucket = &mut self.table[bucket_i];
+            let [h1, h2]: &[S; 2] = unsafe { transmute(&bucket.0) };
+
+            let mask = (h1.cmp_eq(keys) | h2.cmp_eq(keys)).move_mask() as u8;
+            if mask > 0 {
+                // Element already exists.
+                return false;
+            }
+
+            let c0 = h1.cmp_eq(S::ZERO).move_mask().count_ones() as usize;
+            let c1 = h2.cmp_eq(S::ZERO).move_mask().count_ones() as usize;
+            let taken = BUCKET_SIZE - c0 - c1;
+
+            if taken < BUCKET_SIZE {
+                let element_i = taken;
+                let element = &mut bucket.0[element_i];
+                if *element == 0 {
+                    self.hits += 1;
+                    *element = key;
+                    self.len += 1;
+                    self.skips = i;
+                    self.skips2 += i * i;
+                    return true;
+                }
+                panic!();
+            }
+
+            bucket_i += 1;
+            i += 1;
+            self.skips += 1;
+        }
+    }
+
+    #[inline(always)]
+    pub fn insert_in_order(&mut self, key: u64) {
+        self.len += 1;
+        assert!(
+            self.len <= self.buckets * BUCKET_SIZE,
+            "Inserted too many keys!"
+        );
+        if key == 0 {
+            assert!(self.last_key == 0, "Keys must be inserted in order");
             self.has_zero = true;
             return;
         }
-        let bucket_mask = self.table.len() - 1;
-        let element_offset_in_bucket = (key >> 61) as usize;
-        let mut bucket_i = key as usize;
-
-        loop {
-            // Safety: bucket_mask is correct because the number of buckets is a power of 2.
-            let bucket = unsafe { self.table.get_unchecked_mut(bucket_i & bucket_mask) };
-            for element_i in 0..BUCKET_SIZE {
-                let element = &mut bucket.0[(element_i + element_offset_in_bucket) % BUCKET_SIZE];
-                if *element == 0 {
-                    *element = key;
-                    self.len += 1;
-                    return;
-                }
-                if *element == key {
-                    return;
-                }
-            }
-            bucket_i += 1;
-        }
+        assert!(key > self.last_key, "Keys must be inserted in order");
+        self.last_key = key;
+        let hash64 = key;
+        let bucket_i = self.bucket_idx(hash64);
+        // same bucket?
+        self.last_j = select_unpredictable(bucket_i > self.last_b, 0, self.last_j + 1);
+        self.last_b = self.last_b.max(bucket_i);
+        self.last_b += self.last_j >> 3;
+        self.last_j &= 7;
+        self.hits += 1;
+        self.skips += self.last_b - bucket_i;
+        self.skips2 += (self.last_b - bucket_i).pow(2);
+        self.table[self.last_b].0[self.last_j] = key;
     }
 }

--- a/src/hashset.rs
+++ b/src/hashset.rs
@@ -5,12 +5,10 @@
 //! we may need to do longer probe sequences (each probe is 8 bytes, not 1 byte), but on the other hand we only take
 //! 1 cache miss per access, not 2.
 
-use std::arch::x86_64::{_mm_prefetch, _MM_HINT_T0};
+use std::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
 use std::hint::select_unpredictable;
-use std::mem::transmute;
 type S = wide::i64x4;
 
-use rustc_hash::FxHashMap;
 use wide::CmpEq;
 
 fn mul_high(a: u64, b: usize) -> usize {
@@ -36,7 +34,7 @@ const BUCKET_SIZE: usize = 8;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(align(64))] // Cache line alignment
-struct Bucket([u64; BUCKET_SIZE]);
+struct Bucket([S; 2]);
 
 impl U64HashSet {
     pub fn with_capacity(n: usize) -> Self {
@@ -44,7 +42,7 @@ impl U64HashSet {
         let capacity = n * 15 / 10;
         eprintln!("CAPACITY {capacity:>10}");
         let buckets = capacity.div_ceil(BUCKET_SIZE);
-        let table = vec![Bucket([0u64; BUCKET_SIZE]); buckets + PADDING].into_boxed_slice();
+        let table = vec![Bucket([S::ZERO; 2]); buckets + PADDING].into_boxed_slice();
         Self {
             buckets,
             table,
@@ -65,12 +63,9 @@ impl U64HashSet {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = u64> {
-        std::iter::repeat_n(0, self.has_zero as usize).chain(
-            self.table
-                .iter()
-                .flat_map(|b| b.0.iter().copied())
-                .filter(|x| *x != 0),
-        )
+        let (prefix, flat, suffix) = unsafe { self.table.align_to::<u64>() };
+        assert!(prefix == &[] && suffix == &[]);
+        std::iter::repeat_n(0, self.has_zero as usize).chain(flat.iter().copied().filter(|x| *x != 0))
     }
 
     pub fn test(&self) {
@@ -80,7 +75,7 @@ impl U64HashSet {
                 let hash64 = x;
                 let bucket_i = mul_high(hash64, self.buckets);
 
-                let [h1, h2]: &[S; 2] = unsafe { transmute(&self.table[bucket_i]) };
+                let [h1, h2]: &[S; 2] = &self.table[bucket_i].0;
                 let c0 = h1.cmp_eq(S::ZERO).move_mask().count_ones() as usize;
                 let c1 = h2.cmp_eq(S::ZERO).move_mask().count_ones() as usize;
                 let elems = BUCKET_SIZE - c0 - c1;
@@ -111,7 +106,7 @@ impl U64HashSet {
         let mut sum = 0;
         let mut cnt = 0;
         for bucket in &self.table {
-            let [h1, h2]: &[S; 2] = unsafe { transmute(&bucket.0) };
+            let [h1, h2]: &[S; 2] = &bucket.0;
             let c0 = h1.cmp_eq(S::ZERO).move_mask().count_ones() as usize;
             let c1 = h2.cmp_eq(S::ZERO).move_mask().count_ones() as usize;
             let elems = BUCKET_SIZE - c0 - c1;
@@ -139,7 +134,6 @@ impl U64HashSet {
     pub fn prefetch(&self, key: u64) {
         let hash64 = key;
         let bucket_i = self.bucket_idx(hash64);
-        // Safety: bucket_mask is correct because the number of buckets is a power of 2.
         unsafe {
             _mm_prefetch::<_MM_HINT_T0>(
                 self.table.get_unchecked(bucket_i) as *const Bucket as *const i8
@@ -160,10 +154,7 @@ impl U64HashSet {
         let keys = S::splat(key as i64);
 
         loop {
-            use std::mem::transmute;
-            // Safety: bucket_mask is correct because the number of buckets is a power of 2.
-            let bucket = unsafe { self.table.get_unchecked(bucket_i) };
-            let [h1, h2]: &[S; 2] = unsafe { transmute(&bucket.0) };
+            let [h1, h2]: &[S; 2] = &self.table[bucket_i].0;
             let mask = (h1.cmp_eq(keys) | h2.cmp_eq(keys)).move_mask() as u8;
             if mask > 0 {
                 return true;
@@ -191,9 +182,8 @@ impl U64HashSet {
 
         let mut i = 0;
         loop {
-            // Safety: bucket_mask is correct because the number of buckets is a power of 2.
             let bucket = &mut self.table[bucket_i];
-            let [h1, h2]: &[S; 2] = unsafe { transmute(&bucket.0) };
+            let [h1, h2]: &[S; 2] = &bucket.0;
 
             let mask = (h1.cmp_eq(keys) | h2.cmp_eq(keys)).move_mask() as u8;
             if mask > 0 {
@@ -207,16 +197,14 @@ impl U64HashSet {
 
             if taken < BUCKET_SIZE {
                 let element_i = taken;
-                let element = &mut bucket.0[element_i];
-                if *element == 0 {
-                    self.hits += 1;
-                    *element = key;
-                    self.len += 1;
-                    self.skips = i;
-                    self.skips2 += i * i;
-                    return true;
-                }
-                panic!();
+                let element = &mut bucket.0[element_i / 4].as_array_mut()[element_i % 4];
+                assert_eq!(*element, 0);
+                self.hits += 1;
+                *element = key as i64;
+                self.len += 1;
+                self.skips = i;
+                self.skips2 += i * i;
+                return true;
             }
 
             bucket_i += 1;
@@ -249,6 +237,6 @@ impl U64HashSet {
         self.hits += 1;
         self.skips += self.last_b - bucket_i;
         self.skips2 += (self.last_b - bucket_i).pow(2);
-        self.table[self.last_b].0[self.last_j] = key;
+        self.table[self.last_b].0[self.last_j / 4].as_array_mut()[self.last_j] = key as i64;
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -187,8 +187,13 @@ pub fn write_minimizers(
     encode_into_std_write(count, &mut writer, config)
         .context("Failed to serialise minimizer count")?;
 
+    eprintln!("Sorting minimizer hashes..");
+    let mut hashes: Vec<_> = minimizers.into_iter().collect();
+    hashes.sort_unstable();
+
+    eprintln!("Writing minimizer hashes..");
     // Serialise each minimizer directly
-    for hash in minimizers {
+    for hash in hashes {
         encode_into_std_write(hash, &mut writer, config)
             .context("Failed to serialise minimizer hash")?;
     }

--- a/src/index.rs
+++ b/src/index.rs
@@ -96,6 +96,10 @@ pub fn load_minimizer_hashes_cached<P: AsRef<Path>>(
 fn load_minimizer_hashes_varint(mut reader: impl std::io::Read) -> Result<HashSet> {
     let config = bincode::config::standard();
 
+    println!(
+        "Use `deacon index convert <old> <new>` to upgrade the index to the faster and smaller v3 format."
+    );
+
     // Deserialise the count of minimizers so we can init a FxHashSet with the right capacity
     let count: usize = decode_from_std_read(&mut reader, config)
         .context("Failed to deserialise minimizer count")?;
@@ -126,7 +130,7 @@ fn load_minimizer_hashes_fixedint(mut reader: impl std::io::Read) -> Result<Hash
         reader.read_exact(batch).unwrap();
         for h in batch.as_chunks::<8>().0 {
             // Read as little-endian.
-            minimizers.insert(u64::from_le_bytes(*h));
+            minimizers.insert_in_order(u64::from_le_bytes(*h));
         }
     }
 
@@ -247,8 +251,7 @@ pub fn build(config: &IndexConfig) -> Result<()> {
 
     // Init FxHashSet with user-specified capacity
     let capacity = config.capacity_millions * 1_000_000;
-    let mut all_minimizers: HashSet =
-        HashSet::with_capacity(capacity);
+    let mut all_minimizers: HashSet = HashSet::with_capacity(capacity);
 
     eprintln!(
         "Building index (k={}, w={})",
@@ -341,7 +344,12 @@ pub fn build(config: &IndexConfig) -> Result<()> {
     let header = IndexHeader::new(config.kmer_length, config.window_size);
 
     // Write to output path or stdout
-    write_minimizers(all_minimizers.len(), all_minimizers.iter(), &header, config.output_path.as_ref())?;
+    write_minimizers(
+        all_minimizers.len(),
+        all_minimizers.iter(),
+        &header,
+        config.output_path.as_ref(),
+    )?;
 
     let total_time = start_time.elapsed();
     eprintln!("Completed in {:.2?}", total_time);
@@ -507,7 +515,12 @@ pub fn diff<P: AsRef<Path>>(
             first_minimizers.len()
         );
 
-        write_minimizers(first_minimizers.len(), first_minimizers.iter().copied(), &header, output)?;
+        write_minimizers(
+            first_minimizers.len(),
+            first_minimizers.iter().copied(),
+            &header,
+            output,
+        )?;
 
         let total_time = start_time.elapsed();
         eprintln!("Completed difference operation in {:.2?}", total_time);
@@ -555,7 +568,12 @@ pub fn diff<P: AsRef<Path>>(
                 first_minimizers.len()
             );
 
-            write_minimizers(first_minimizers.len(), first_minimizers.iter().copied(), &header, output)?;
+            write_minimizers(
+                first_minimizers.len(),
+                first_minimizers.iter().copied(),
+                &header,
+                output,
+            )?;
 
             let total_time = start_time.elapsed();
             eprintln!("Completed difference operation in {:.2?}", total_time);
@@ -580,7 +598,12 @@ pub fn diff<P: AsRef<Path>>(
         first_minimizers.len()
     );
 
-    write_minimizers(first_minimizers.len(), first_minimizers.iter().copied(), &header, output)?;
+    write_minimizers(
+        first_minimizers.len(),
+        first_minimizers.iter().copied(),
+        &header,
+        output,
+    )?;
 
     let total_time = start_time.elapsed();
     eprintln!("Completed diff operation in {:.2?}", total_time);
@@ -619,7 +642,12 @@ pub fn convert_index<P: AsRef<Path>>(from: P, to: P) -> Result<()> {
     assert_eq!(header.format_version, 2);
     header.format_version = 3;
     let start_time = Instant::now();
-    write_minimizers(minimizers.len(), minimizers.iter(), &header, Some(&to.as_ref().to_owned()))?;
+    write_minimizers(
+        minimizers.len(),
+        minimizers.iter(),
+        &header,
+        Some(&to.as_ref().to_owned()),
+    )?;
     let write_time = start_time.elapsed();
     eprintln!("Wrote index in {:.2?}", write_time);
 
@@ -695,8 +723,7 @@ pub fn union<P: AsRef<Path>>(
     }
 
     // Pre-allocate hash set with total capacity to avoid resizing
-    let mut all_minimizers: HashSet =
-        HashSet::with_capacity(total_capacity);
+    let mut all_minimizers: HashSet = HashSet::with_capacity(total_capacity);
 
     // Now load and merge all indexes
     for (i, path) in inputs.iter().enumerate() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(core_intrinsics, impl_trait_in_assoc_type)]
 //! # Deacon
 //!
 //! A fast minimizer-based filter for nucleotide sequences in FASTA or FASTQ format,
@@ -24,7 +23,7 @@ pub use minimizers::{
 };
 
 use anyhow::Result;
-// use rustc_hash::FxHashSet as HashSet;
+type FxHashSet = rustc_hash::FxHashSet<u64>;
 use hashset::U64HashSet as HashSet;
 use std::path::{Path, PathBuf};
 
@@ -270,5 +269,5 @@ pub fn write_minimizers(
     header: &index::IndexHeader,
     output_path: Option<&PathBuf>,
 ) -> Result<()> {
-    index::write_minimizers(minimizers, header, output_path)
+    index::write_minimizers(minimizers.len(), minimizers.iter(), header, output_path)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,22 +9,24 @@
 
 // Re-export public functionality
 pub mod filter;
+mod hashset;
 pub mod index;
 pub mod minimizers;
-mod hashset;
 
 // Re-export the important structures and functions for library users
-pub use filter::{FilterSummary, run as run_filter};
+pub use filter::{run as run_filter, FilterSummary};
 pub use index::{
-    IndexHeader, build as build_index, diff as diff_index, info as index_info, union as union_index,
+    build as build_index, diff as diff_index, info as index_info, union as union_index, IndexHeader,
 };
 pub use minimizers::{
-    DEFAULT_KMER_LENGTH, DEFAULT_WINDOW_SIZE, compute_minimizer_hashes, fill_minimizer_hashes,
+    compute_minimizer_hashes, fill_minimizer_hashes, DEFAULT_KMER_LENGTH, DEFAULT_WINDOW_SIZE,
 };
 
 use anyhow::Result;
-type FxHashSet = rustc_hash::FxHashSet<u64>;
+// Use insert-only hashset whenever possible.
 use hashset::U64HashSet as HashSet;
+// Fall back to proper FxHashSet for set operations.
+type FxHashSet = rustc_hash::FxHashSet<u64>;
 use std::path::{Path, PathBuf};
 
 pub struct FilterConfig<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(core_intrinsics, impl_trait_in_assoc_type)]
 //! # Deacon
 //!
 //! A fast minimizer-based filter for nucleotide sequences in FASTA or FASTQ format,
@@ -11,6 +12,7 @@
 pub mod filter;
 pub mod index;
 pub mod minimizers;
+mod hashset;
 
 // Re-export the important structures and functions for library users
 pub use filter::{FilterSummary, run as run_filter};
@@ -22,7 +24,8 @@ pub use minimizers::{
 };
 
 use anyhow::Result;
-use rustc_hash::FxHashSet;
+// use rustc_hash::FxHashSet as HashSet;
+use hashset::U64HashSet as HashSet;
 use std::path::{Path, PathBuf};
 
 pub struct FilterConfig<'a> {
@@ -258,12 +261,12 @@ impl IndexConfig {
     }
 }
 
-pub fn load_minimizers<P: AsRef<Path>>(path: P) -> Result<(FxHashSet<u64>, index::IndexHeader)> {
+pub fn load_minimizers<P: AsRef<Path>>(path: P) -> Result<(HashSet, index::IndexHeader)> {
     index::load_minimizer_hashes(&path)
 }
 
 pub fn write_minimizers(
-    minimizers: &FxHashSet<u64>,
+    minimizers: &HashSet,
     header: &index::IndexHeader,
     output_path: Option<&PathBuf>,
 ) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
+use deacon::index::convert_index;
 use deacon::{
     DEFAULT_KMER_LENGTH, DEFAULT_WINDOW_SIZE, FilterConfig, IndexConfig, diff_index, index_info,
     union_index,
@@ -169,6 +170,11 @@ enum IndexCommands {
         #[arg(short = 'o', long = "output", default_value = "-")]
         output: Option<PathBuf>,
     },
+    Convert {
+        /// Path to index file
+        from: PathBuf,
+        to: PathBuf,
+    },
 }
 
 #[cfg(feature = "server")]
@@ -307,6 +313,9 @@ fn process_command(command: &Commands) -> Result<(), anyhow::Error> {
             } => {
                 diff_index(first, second, *kmer_length, *window_size, output.as_ref())
                     .context("Failed to run index diff command")?;
+            }
+            IndexCommands::Convert { from, to } => {
+                convert_index(from, to)?;
             }
         },
         Commands::Filter {


### PR DESCRIPTION
- Replaces `FxHashSet` by a custom flat hashset
- 2s to load index instead of ~5s
- slightly (~5%) slower to query
- but fixed 50% memory overhead, rather than anywhere between 25% and 150% for normal hashset.
- (There's a memory - speed tradeoff. At 30% overhead it's 10% slower again, but at 100% overhead it's as fast.)

This depends on the new index version #49, that should be merged first.

Not super sure it this is a win overall given the added complexity.
It might make more sense for me to optimize this further and extract it into a separate crate.

Anyway feel free to try it.