### PR TITLE
AsRef<Path> => &Path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,9 +195,9 @@ pub struct IndexConfig {
 
 impl IndexConfig {
     /// Create a new index configuration with the specified input path
-    pub fn new<P: AsRef<Path>>(input_path: P) -> Self {
+    pub fn new(input_path: PathBuf) -> Self {
         Self {
-            input_path: input_path.as_ref().to_path_buf(),
+            input_path: input_path,
             kmer_length: DEFAULT_KMER_LENGTH,
             window_size: DEFAULT_WINDOW_SIZE,
             output_path: None,
@@ -221,8 +221,8 @@ impl IndexConfig {
     }
 
     /// Set output path
-    pub fn with_output<P: AsRef<Path>>(mut self, output_path: P) -> Self {
-        self.output_path = Some(output_path.as_ref().to_path_buf());
+    pub fn with_output(mut self, output_path: PathBuf) -> Self {
+        self.output_path = Some(output_path);
         self
     }
 
@@ -256,14 +256,14 @@ impl IndexConfig {
     }
 }
 
-pub fn load_minimizers<P: AsRef<Path>>(path: P) -> Result<(FxHashSet<u64>, index::IndexHeader)> {
-    index::load_minimizer_hashes(&path)
+pub fn load_minimizers(path: &Path) -> Result<(FxHashSet<u64>, index::IndexHeader)> {
+    index::load_minimizer_hashes(path)
 }
 
 pub fn write_minimizers(
     minimizers: &FxHashSet<u64>,
     header: &index::IndexHeader,
-    output_path: Option<&PathBuf>,
+    output_path: Option<&Path>,
 ) -> Result<()> {
     index::write_minimizers(minimizers, header, output_path)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -308,7 +308,7 @@ fn process_command(command: &Commands) -> Result<(), anyhow::Error> {
                 output,
                 capacity_millions,
             } => {
-                union_index(inputs, output.as_ref(), *capacity_millions)
+                union_index(inputs, output.as_deref(), *capacity_millions)
                     .context("Failed to run index union command")?;
             }
             IndexCommands::Diff {
@@ -318,11 +318,11 @@ fn process_command(command: &Commands) -> Result<(), anyhow::Error> {
                 window_size,
                 output,
             } => {
-                diff_index(first, second, *kmer_length, *window_size, output.as_ref())
+                diff_index(first, second, *kmer_length, *window_size, output.as_deref())
                     .context("Failed to run index diff command")?;
             }
             IndexCommands::Convert { input, output } => {
-                convert_index(input, output.clone())?;
+                convert_index(input, output.as_deref())?;
             }
         },
         Commands::Filter {


### PR DESCRIPTION
Drop not-really-needed usage of `P: AsPath` generics.