### PR TITLE
Drop `capacity_millions` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,6 @@ Options:
           Minimizer window size used for indexing [default: 15]
   -o, --output <OUTPUT>
           Path to output file (- for stdout) [default: -]
-  -c, --capacity <CAPACITY_MILLIONS>
-          Preallocated index capacity in millions of minimizers [default: 400]
   -t, --threads <THREADS>
           Number of execution threads (0 = auto) [default: 8]
   -q, --quiet

--- a/src/index.rs
+++ b/src/index.rs
@@ -627,16 +627,11 @@ pub fn union(inputs: &[PathBuf], output: Option<&Path>) -> Result<()> {
 
     // Read all headers first to determine total capacity needed
     let mut headers_and_counts = Vec::new();
-    let mut sum_capacity = 0;
 
     for path in inputs {
         let (header, count) = load_header_and_count(path)?;
-        sum_capacity += count;
         headers_and_counts.push((header, count));
     }
-
-    // Use provided capacity or fall back to sum of all index counts
-    let total_capacity = sum_capacity;
 
     // Get header from first file for output
     let header = &headers_and_counts[0].0;
@@ -645,11 +640,6 @@ pub fn union(inputs: &[PathBuf], output: Option<&Path>) -> Result<()> {
         "Performing union of indexes (k={}, w={})",
         header.kmer_length(),
         header.window_size()
-    );
-    eprintln!(
-        "Pre-allocating worst-case capacity for {} minimizers from {} indexes",
-        total_capacity,
-        inputs.len()
     );
 
     // Verify all headers are compatible
@@ -669,8 +659,7 @@ pub fn union(inputs: &[PathBuf], output: Option<&Path>) -> Result<()> {
     }
 
     // Pre-allocate hash set with total capacity to avoid resizing
-    let mut all_minimizers: FxHashSet<u64> =
-        FxHashSet::with_capacity_and_hasher(total_capacity, Default::default());
+    let mut all_minimizers = FxHashSet::<u64>::default();
 
     // Now load and merge all indexes
     for (i, path) in inputs.iter().enumerate() {

--- a/src/index.rs
+++ b/src/index.rs
@@ -82,8 +82,7 @@ pub fn load_minimizer_hashes_cached(
         (path.to_owned(), m, h)
     });
     assert_eq!(
-        p,
-        path,
+        p, path,
         "Currently, the server can only have one index loaded."
     );
 
@@ -136,8 +135,7 @@ fn load_minimizer_hashes_fixedint(mut reader: impl std::io::Read) -> Result<FxHa
 /// This new version uses fixed-width integer encoding.
 /// Use `deacon index convert` to convert from the old format.
 pub fn load_minimizer_hashes(path: &Path) -> Result<(FxHashSet<u64>, IndexHeader)> {
-    let file =
-        File::open(path).context(format!("Failed to open index file {:?}", path))?;
+    let file = File::open(path).context(format!("Failed to open index file {:?}", path))?;
     let mut reader = BufReader::with_capacity(1 << 20, file);
     let config = bincode::config::standard().with_fixed_int_encoding();
 
@@ -203,7 +201,6 @@ pub fn build(config: &IndexConfig) -> Result<()> {
 
     // Build options string similar to filter
     let mut options = Vec::<String>::new();
-    options.push(format!("capacity={}M", config.capacity_millions));
     if config.threads > 0 {
         options.push(format!("threads={}", config.threads));
     }
@@ -240,9 +237,7 @@ pub fn build(config: &IndexConfig) -> Result<()> {
     };
 
     // Init FxHashSet with user-specified capacity
-    let capacity = config.capacity_millions * 1_000_000;
-    let mut all_minimizers: FxHashSet<u64> =
-        FxHashSet::with_capacity_and_hasher(capacity, Default::default());
+    let mut all_minimizers = FxHashSet::<u64>::default();
 
     eprintln!(
         "Building index (k={}, w={})",
@@ -621,11 +616,7 @@ pub fn convert_index(from: &Path, to: Option<&Path>) -> Result<()> {
 }
 
 /// Combine minimizer indexes (set union)
-pub fn union(
-    inputs: &[PathBuf],
-    output: Option<&Path>,
-    capacity_millions: Option<usize>,
-) -> Result<()> {
+pub fn union(inputs: &[PathBuf], output: Option<&Path>) -> Result<()> {
     let start_time = Instant::now();
     // Check input files
     if inputs.is_empty() {
@@ -645,11 +636,7 @@ pub fn union(
     }
 
     // Use provided capacity or fall back to sum of all index counts
-    let total_capacity = if let Some(capacity_millions) = capacity_millions {
-        capacity_millions * 1_000_000
-    } else {
-        sum_capacity
-    };
+    let total_capacity = sum_capacity;
 
     // Get header from first file for output
     let header = &headers_and_counts[0].0;
@@ -659,18 +646,11 @@ pub fn union(
         header.kmer_length(),
         header.window_size()
     );
-    if capacity_millions.is_some() {
-        eprintln!(
-            "Pre-allocating user-specified capacity for {} minimizers",
-            total_capacity
-        );
-    } else {
-        eprintln!(
-            "No capacity specified, pre-allocating worst-case capacity for {} minimizers from {} indexes",
-            total_capacity,
-            inputs.len()
-        );
-    }
+    eprintln!(
+        "Pre-allocating worst-case capacity for {} minimizers from {} indexes",
+        total_capacity,
+        inputs.len()
+    );
 
     // Verify all headers are compatible
     for (i, (file_header, _)) in headers_and_counts.iter().enumerate() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,9 +180,6 @@ pub struct IndexConfig {
     /// Path to output file (None for stdout)
     pub output_path: Option<PathBuf>,
 
-    /// Hash table pre-allocation capacity in millions
-    pub capacity_millions: usize,
-
     /// Number of execution threads (0 = auto)
     pub threads: usize,
 
@@ -201,7 +198,6 @@ impl IndexConfig {
             kmer_length: DEFAULT_KMER_LENGTH,
             window_size: DEFAULT_WINDOW_SIZE,
             output_path: None,
-            capacity_millions: 400,
             threads: 8,
             quiet: false,
             entropy_threshold: 0.0,
@@ -223,12 +219,6 @@ impl IndexConfig {
     /// Set output path
     pub fn with_output(mut self, output_path: PathBuf) -> Self {
         self.output_path = Some(output_path);
-        self
-    }
-
-    /// Set hash table capacity in millions
-    pub fn with_capacity_millions(mut self, capacity_millions: usize) -> Self {
-        self.capacity_millions = capacity_millions;
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,9 +195,9 @@ pub struct IndexConfig {
 
 impl IndexConfig {
     /// Create a new index configuration with the specified input path
-    pub fn new<P: AsRef<Path>>(input_path: P) -> Self {
+    pub fn new(input_path: PathBuf) -> Self {
         Self {
-            input_path: input_path.as_ref().to_path_buf(),
+            input_path: input_path,
             kmer_length: DEFAULT_KMER_LENGTH,
             window_size: DEFAULT_WINDOW_SIZE,
             output_path: None,
@@ -221,8 +221,8 @@ impl IndexConfig {
     }
 
     /// Set output path
-    pub fn with_output<P: AsRef<Path>>(mut self, output_path: P) -> Self {
-        self.output_path = Some(output_path.as_ref().to_path_buf());
+    pub fn with_output(mut self, output_path: PathBuf) -> Self {
+        self.output_path = Some(output_path);
         self
     }
 
@@ -256,14 +256,14 @@ impl IndexConfig {
     }
 }
 
-pub fn load_minimizers<P: AsRef<Path>>(path: P) -> Result<(FxHashSet<u64>, index::IndexHeader)> {
-    index::load_minimizer_hashes(&path)
+pub fn load_minimizers(path: &Path) -> Result<(FxHashSet<u64>, index::IndexHeader)> {
+    index::load_minimizer_hashes(path)
 }
 
 pub fn write_minimizers(
     minimizers: &FxHashSet<u64>,
     header: &index::IndexHeader,
-    output_path: Option<&PathBuf>,
+    output_path: Option<&Path>,
 ) -> Result<()> {
     index::write_minimizers(minimizers, header, output_path)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -308,7 +308,7 @@ fn process_command(command: &Commands) -> Result<(), anyhow::Error> {
                 output,
                 capacity_millions,
             } => {
-                union_index(inputs, output.as_ref(), *capacity_millions)
+                union_index(inputs, output.as_deref(), *capacity_millions)
                     .context("Failed to run index union command")?;
             }
             IndexCommands::Diff {
@@ -318,11 +318,11 @@ fn process_command(command: &Commands) -> Result<(), anyhow::Error> {
                 window_size,
                 output,
             } => {
-                diff_index(first, second, *kmer_length, *window_size, output.as_ref())
+                diff_index(first, second, *kmer_length, *window_size, output.as_deref())
                     .context("Failed to run index diff command")?;
             }
             IndexCommands::Convert { input, output } => {
-                convert_index(input, output.clone())?;
+                convert_index(input, output.as_deref())?;
             }
         },
         Commands::Filter {

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,10 +117,6 @@ enum IndexCommands {
         #[arg(short = 'o', long = "output")]
         output: Option<PathBuf>,
 
-        /// Preallocated index capacity in millions of minimizers
-        #[arg(short = 'c', long = "capacity", default_value_t = 400)]
-        capacity_millions: usize,
-
         /// Number of execution threads (0 = auto)
         #[arg(short = 't', long = "threads", default_value_t = 8)]
         threads: usize,
@@ -147,10 +143,6 @@ enum IndexCommands {
         /// Path to output file (stdout if not specified)
         #[arg(short = 'o', long = "output")]
         output: Option<PathBuf>,
-
-        /// Preallocated index capacity in millions of minimizers (overrides sum-based allocation)
-        #[arg(short = 'c', long = "capacity")]
-        capacity_millions: Option<usize>,
     },
     /// Subtract minimizers in one index from another (A - B)
     Diff {
@@ -281,7 +273,6 @@ fn process_command(command: &Commands) -> Result<(), anyhow::Error> {
                 kmer_length,
                 window_size,
                 output,
-                capacity_millions,
                 threads,
                 quiet,
                 entropy_threshold,
@@ -291,7 +282,6 @@ fn process_command(command: &Commands) -> Result<(), anyhow::Error> {
                     kmer_length: *kmer_length,
                     window_size: *window_size,
                     output_path: output.clone(),
-                    capacity_millions: *capacity_millions,
                     threads: *threads,
                     quiet: *quiet,
                     entropy_threshold: *entropy_threshold,
@@ -306,9 +296,8 @@ fn process_command(command: &Commands) -> Result<(), anyhow::Error> {
             IndexCommands::Union {
                 inputs,
                 output,
-                capacity_millions,
             } => {
-                union_index(inputs, output.as_deref(), *capacity_millions)
+                union_index(inputs, output.as_deref())
                     .context("Failed to run index union command")?;
             }
             IndexCommands::Diff {


### PR DESCRIPTION
This seems brittle and hard to use correctly.
Better to simply let the `FxHashMap` double in size whenever needed.
This also significantly speeds up tests because now they don't have to do 2GB allocations for each small test.

Should be merged after #53.