### PR TITLE
Drop needletail dep

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -249,14 +249,15 @@ struct FilterProcessor {
     filtering_start_time: Instant,
 }
 
-#[derive(Clone, Default)]
-struct ProcessingStats {
-    total_seqs: u64,
+#[derive(Clone, Default, Debug)]
+pub(crate) struct ProcessingStats {
+    pub total_seqs: u64,
     filtered_seqs: u64,
-    total_bp: u64,
+    pub total_bp: u64,
     output_bp: u64,
     filtered_bp: u64,
     output_seq_counter: u64,
+    pub last_reported: u64,
 }
 
 #[derive(Default, Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,8 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use deacon::index::convert_index;
 use deacon::{
-    DEFAULT_KMER_LENGTH, DEFAULT_WINDOW_SIZE, FilterConfig, IndexConfig, diff_index, index_info,
-    union_index,
+    diff_index, index_info, union_index, FilterConfig, IndexConfig, DEFAULT_KMER_LENGTH,
+    DEFAULT_WINDOW_SIZE,
 };
 use serde::{Deserialize, Serialize};
 use std::io::{Read, Write};
@@ -158,6 +158,10 @@ enum IndexCommands {
         #[arg(short = 'w', long = "window-size")]
         window_size: Option<u8>,
 
+        /// Number of execution threads (0 = auto)
+        #[arg(short = 't', long = "threads", default_value_t = 8)]
+        threads: usize,
+
         /// Path to output file (stdout if not specified)
         #[arg(short = 'o', long = "output")]
         output: Option<PathBuf>,
@@ -294,9 +298,17 @@ fn process_command(command: &Commands) -> Result<(), anyhow::Error> {
                 kmer_length,
                 window_size,
                 output,
+                threads,
             } => {
-                diff_index(first, second, *kmer_length, *window_size, output.as_deref())
-                    .context("Failed to run index diff command")?;
+                diff_index(
+                    first,
+                    second,
+                    *kmer_length,
+                    *window_size,
+                    *threads,
+                    output.as_deref(),
+                )
+                .context("Failed to run index diff command")?;
             }
             IndexCommands::Convert { input, output } => {
                 convert_index(input, output.as_deref())?;


### PR DESCRIPTION
This replaces the custom batching logic for `index build` and `index diff` by paraseq `ParallelProcessor`s.

Not sure it's 100% equivalent, but it seems to work fine. But please check. Might be that the new versions use more memory.

I set the batch size for paraseq to 1 to that input chromosomes are processed 1 at a time, but I'm not really sure how this works when the input is short reads instead; I hope it still does batching in that case.

It might be that just doing the logic here sequentially makes more sense, since 90% of time is anyway spend on building/removing from a single big hashmap.