### PR TITLE
Update packed-seq and simd-mini and avoid internal allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,9 +709,9 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "packed-seq"
-version = "4.1.1"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7fb7df305879ff294f417f4bee127a86925f2d46760150822f114e8ed50a3e7"
+checksum = "534d46109326ee0a3f0e157c305cf51b7ec73d1757f783a378e5821648f0357a"
 dependencies = [
  "cfg-if",
  "mem_dbg",
@@ -915,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.18"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
@@ -1043,9 +1043,9 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "seq-hash"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce5191beda915ffc179068126f1ef8061c2a4ee3b9a87ed4dbbdf7c329cc5c3"
+checksum = "223c0987220362a4373b52ab3ffb9bbc7e3e6bcabf9460804e4cc443ff727976"
 dependencies = [
  "packed-seq",
  "wide",
@@ -1108,9 +1108,9 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simd-minimizers"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b9f62f1b33e7d86e791794d2bc3a72e83d2723f8d57fb6e1bc5e56458f05bd7"
+checksum = "e5440a52a18475de999f8a1739c99a128a5661658e04b68bcfc675b66cc66582"
 dependencies = [
  "clap",
  "itertools",
@@ -1405,9 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.5"
+version = "0.53.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
 dependencies = [
  "windows-link",
  "windows_aarch64_gnullvm",
@@ -1422,51 +1422,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ rapidhash = "4.1.0"
 parking_lot = "0.12"
 indicatif = "0.18"
 
-packed-seq = "4.1.1"
-simd-minimizers = "2.1.0"
+packed-seq = "4.2.0"
+simd-minimizers = "2.2.0"
 
 needletail = { version = "0.6", default-features = false }
 niffler = { version = "3", default-features = false }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -3,7 +3,7 @@ use crate::minimizers::{KmerHasher, decode_u64, decode_u128};
 use crate::{FilterConfig, MinimizerSet};
 use anyhow::{Context, Result};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
-use packed_seq::{PackedNSeqVec, SeqVec};
+use packed_seq::{PackedNSeqVec, SeqVec, u32x8};
 use paraseq::Record;
 use paraseq::fastx::Reader;
 use paraseq::parallel::{PairedParallelProcessor, ParallelProcessor, ParallelReader};
@@ -262,6 +262,7 @@ pub(crate) struct Buffers {
     pub packed_nseq: PackedNSeqVec,
     pub positions: Vec<u32>,
     pub minimizers: crate::MinimizerVec,
+    pub cache: (simd_minimizers::Cache, Vec<u32x8>, Vec<u32x8>),
 }
 
 impl Buffers {
@@ -273,6 +274,7 @@ impl Buffers {
             },
             positions: Default::default(),
             minimizers: crate::MinimizerVec::U64(Vec::new()),
+            cache: Default::default(),
         }
     }
 
@@ -284,6 +286,7 @@ impl Buffers {
             },
             positions: Default::default(),
             minimizers: crate::MinimizerVec::U128(Vec::new()),
+            cache: Default::default(),
         }
     }
 }
@@ -408,6 +411,7 @@ impl FilterProcessor {
             packed_nseq,
             positions,
             minimizers,
+            cache,
         } = &mut self.buffers;
 
         packed_nseq.seq.clear();
@@ -424,7 +428,7 @@ impl FilterProcessor {
         let w = self.window_size as usize;
         let m = simd_minimizers::canonical_minimizers(k, w)
             .hasher(&self.hasher)
-            .run_skip_ambiguous_windows(packed_nseq.as_slice(), positions);
+            .run_skip_ambiguous_windows_with_buf(packed_nseq.as_slice(), positions, cache);
 
         // Store k-mer values directly based on variant
         match minimizers {

--- a/src/minimizers.rs
+++ b/src/minimizers.rs
@@ -121,6 +121,7 @@ pub(crate) fn fill_minimizers(
         packed_nseq,
         positions,
         minimizers,
+        cache,
     } = buffers;
 
     packed_nseq.seq.clear();
@@ -140,7 +141,7 @@ pub(crate) fn fill_minimizers(
     // Get minimizer positions using simd-minimizers
     let out = simd_minimizers::canonical_minimizers(kmer_length as usize, window_size as usize)
         .hasher(hasher)
-        .run_skip_ambiguous_windows(packed_nseq.as_slice(), positions);
+        .run_skip_ambiguous_windows_with_buf(packed_nseq.as_slice(), positions, cache);
 
     match minimizers {
         crate::MinimizerVec::U64(vec) => {


### PR DESCRIPTION
- This makes NEON a bunch faster by avoiding bad codegen around `u32x8::splat`.
- Also prevents allocating buffers in inner loops by instead allocating them on the stack and reusing them.