### PR TITLE
add --interleaved support for paired input

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -859,10 +859,11 @@ pub fn run(config: &FilterConfig) -> Result<()> {
 
     let mut input_type = String::new();
     let mut options = Vec::<String>::new();
-    let paired_stdin = config.input_path == "-"
+    let interleaved_stdin = config.input_path == "-"
         && config.input2_path.is_some()
         && config.input2_path.unwrap() == "-";
-    if paired_stdin {
+    let interleaved_input = config.interleaved || interleaved_stdin;
+    if interleaved_input {
         input_type.push_str("interleaved");
     } else if config.input2_path.is_some() {
         input_type.push_str("paired");
@@ -929,12 +930,16 @@ pub fn run(config: &FilterConfig) -> Result<()> {
         config.compression_level,
         compression_threads_per_output,
     )?;
-    let writer2 = if let (Some(output2), Some(_)) = (config.output2_path, config.input2_path) {
-        Some(get_writer(
-            Some(std::path::Path::new(output2)),
-            config.compression_level,
-            compression_threads_per_output,
-        )?)
+    let writer2 = if let Some(output2) = config.output2_path {
+        if config.input2_path.is_some() || interleaved_input {
+            Some(get_writer(
+                Some(std::path::Path::new(output2)),
+                config.compression_level,
+                compression_threads_per_output,
+            )?)
+        } else {
+            None
+        }
     } else {
         None
     };
@@ -988,9 +993,9 @@ pub fn run(config: &FilterConfig) -> Result<()> {
     // Process based on input type - use filtering threads (already calculated above)
     let num_threads = filtering_threads;
 
-    if paired_stdin {
-        // Interleaved paired stdin - use interleaved processor
-        let reader = create_paraseq_reader(Some("-"))?;
+    if interleaved_input {
+        // Interleaved paired input from stdin or a file
+        let reader = create_paraseq_reader(Some(config.input_path))?;
         reader.process_parallel_interleaved(&mut processor, num_threads)?;
     } else if let Some(input2_path) = config.input2_path {
         // Paired files - both must be empty or both non-empty

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,8 +142,11 @@ pub struct FilterConfig<'a> {
     /// Path to input fastx file (or - for stdin)
     pub input_path: &'a str,
 
-    /// Path to optional second paired fastx file (or - for interleaved stdin)
+    /// Path to optional second paired fastx file
     pub input2_path: Option<&'a str>,
+
+    /// Treat input_path as an interleaved paired stream
+    pub interleaved: bool,
 
     /// Path to output fastx file (None for stdout; detects .gz and .zst)
     pub output_path: Option<&'a Path>,
@@ -197,6 +200,7 @@ impl<'a> FilterConfig<'a> {
             minimizers_path,
             input_path: "-",
             input2_path: None,
+            interleaved: false,
             output_path: None,
             output2_path: None,
             abs_threshold: 2,
@@ -222,6 +226,11 @@ impl<'a> FilterConfig<'a> {
 
     pub fn with_input2(mut self, input2_path: &'a str) -> Self {
         self.input2_path = Some(input2_path);
+        self
+    }
+
+    pub fn with_interleaved(mut self, interleaved: bool) -> Self {
+        self.interleaved = interleaved;
         self
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,8 +37,12 @@ enum Commands {
         #[arg(default_value = "-")]
         input: String,
 
-        /// Optional path to second paired fastx file (or - for interleaved stdin)
+        /// Optional path to second paired fastx file
         input2: Option<String>,
+
+        /// Treat INPUT as interleaved paired reads from a file or stdin
+        #[arg(long = "interleaved", default_value_t = false, conflicts_with = "input2")]
+        interleaved: bool,
 
         /// Minimum absolute number of minimizer hits for a match
         #[arg(short = 'a', long = "abs-threshold", default_value_t = 2, value_parser = clap::value_parser!(u16).range(1..))]
@@ -415,6 +419,7 @@ fn process_command(command: &Commands) -> Result<(), anyhow::Error> {
             index: minimizers,
             input,
             input2,
+            interleaved,
             output,
             output2,
             abs_threshold,
@@ -432,7 +437,7 @@ fn process_command(command: &Commands) -> Result<(), anyhow::Error> {
             quiet,
         } => {
             // Validate output2 usage
-            if output2.is_some() && input2.is_none() {
+            if output2.is_some() && input2.is_none() && !interleaved {
                 eprintln!(
                     "Warning: --output2 specified but no second input file provided. --output2 will be ignored."
                 );
@@ -442,6 +447,7 @@ fn process_command(command: &Commands) -> Result<(), anyhow::Error> {
                 minimizers_path: minimizers,
                 input_path: input,
                 input2_path: input2.as_deref(),
+                interleaved: *interleaved,
                 output_path: output.as_ref().map(|p| p.as_path()),
                 output2_path: output2.as_deref(),
                 abs_threshold: *abs_threshold as usize,

--- a/tests/filter_tests.rs
+++ b/tests/filter_tests.rs
@@ -31,6 +31,14 @@ fn create_test_paired_fastq(path1: &Path, path2: &Path) {
     fs::write(path2, fastq_content2).unwrap();
 }
 
+fn create_test_interleaved_fastq(path: &Path) {
+    let interleaved_content =
+        "@read1/1\nACGTGCATAGCTGCATGCATGCATGCATGCATGCATGCAATGCAACGTGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCA\n+\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n@read1/2\nACGTGCATAGCTGCATGCATGCATGCATGCATGCATGCAATGCAACGTGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCA\n+\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
+            .to_owned()
+            + "@read2/1\nTGCAGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATTGCAGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGC\n+\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n@read2/2\nTGCAGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATTGCAGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGC\n+\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
+    fs::write(path, interleaved_content).unwrap();
+}
+
 fn build_index(fasta_path: &Path, bin_path: &Path) {
     let output = StdCommand::new(cargo::cargo_bin!("deacon"))
         .arg("index")
@@ -529,11 +537,7 @@ fn test_interleaved_paired_reads_stdin() {
     // Create test files
     create_test_fasta(&fasta_path);
 
-    let interleaved_content =
-        "@read1/1\nACGTGCATAGCTGCATGCATGCATGCATGCATGCATGCAATGCAACGTGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCA\n+\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n@read1/2\nACGTGCATAGCTGCATGCATGCATGCATGCATGCATGCAATGCAACGTGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCA\n+\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
-            .to_owned()
-            + "@read2/1\nTGCAGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATTGCAGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGC\n+\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n@read2/2\nTGCAGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATTGCAGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGC\n+\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
-    fs::write(&interleaved_fastq_path, interleaved_content).unwrap();
+    create_test_interleaved_fastq(&interleaved_fastq_path);
 
     build_index(&fasta_path, &bin_path);
     assert!(bin_path.exists(), "Index file wasn't created");
@@ -575,11 +579,7 @@ fn test_interleaved_paired_reads_stdin_separate_out() {
     // Create test files
     create_test_fasta(&fasta_path);
 
-    let interleaved_content =
-        "@read1/1\nACGTGCATAGCTGCATGCATGCATGCATGCATGCATGCAATGCAACGTGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCA\n+\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n@read1/2\nACGTGCATAGCTGCATGCATGCATGCATGCATGCATGCAATGCAACGTGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCA\n+\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
-            .to_owned()
-            + "@read2/1\nTGCAGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATTGCAGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGC\n+\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n@read2/2\nTGCAGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATTGCAGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGC\n+\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
-    fs::write(&interleaved_fastq_path, interleaved_content).unwrap();
+    create_test_interleaved_fastq(&interleaved_fastq_path);
 
     build_index(&fasta_path, &bin_path);
     assert!(bin_path.exists(), "Index file wasn't created");
@@ -1208,6 +1208,105 @@ fn test_filter_proportional_paired() {
         output_path.exists(),
         "Output file with proportional threshold for paired reads wasn't created"
     );
+}
+
+#[test]
+fn test_interleaved_paired_reads_file() {
+    let temp_dir = tempdir().unwrap();
+    let fasta_path = temp_dir.path().join("ref.fasta");
+    let interleaved_fastq_path = temp_dir.path().join("interleaved_reads.fastq");
+    let bin_path = temp_dir.path().join("ref.bin");
+    let output_path = temp_dir.path().join("filtered.fastq");
+
+    create_test_fasta(&fasta_path);
+    create_test_interleaved_fastq(&interleaved_fastq_path);
+    build_index(&fasta_path, &bin_path);
+
+    let mut cmd = cargo::cargo_bin_cmd!("deacon");
+    cmd.arg("filter")
+        .arg("--interleaved")
+        .arg("-a")
+        .arg("1")
+        .arg("-r")
+        .arg("0.0")
+        .arg(&bin_path)
+        .arg(&interleaved_fastq_path)
+        .arg("--output")
+        .arg(&output_path)
+        .assert()
+        .success();
+
+    let output_content = fs::read_to_string(&output_path).unwrap();
+    assert!(!output_content.is_empty(), "Output file is empty");
+}
+
+#[test]
+fn test_interleaved_paired_reads_file_separate_out() {
+    let temp_dir = tempdir().unwrap();
+    let fasta_path = temp_dir.path().join("ref.fasta");
+    let interleaved_fastq_path = temp_dir.path().join("interleaved_reads.fastq");
+    let bin_path = temp_dir.path().join("ref.bin");
+    let output_path1 = temp_dir.path().join("filtered_R1.fastq");
+    let output_path2 = temp_dir.path().join("filtered_R2.fastq");
+
+    create_test_fasta(&fasta_path);
+    create_test_interleaved_fastq(&interleaved_fastq_path);
+    build_index(&fasta_path, &bin_path);
+
+    let mut cmd = cargo::cargo_bin_cmd!("deacon");
+    cmd.arg("filter")
+        .arg("--interleaved")
+        .arg("-a")
+        .arg("1")
+        .arg("-r")
+        .arg("0.0")
+        .arg(&bin_path)
+        .arg(&interleaved_fastq_path)
+        .arg("-o")
+        .arg(&output_path1)
+        .arg("-O")
+        .arg(&output_path2)
+        .assert()
+        .success();
+
+    let output1_content = fs::read_to_string(&output_path1).unwrap();
+    let output2_content = fs::read_to_string(&output_path2).unwrap();
+
+    assert!(output1_content.contains("/1"), "R1 output should contain /1 reads");
+    assert!(
+        !output1_content.contains("/2"),
+        "R1 output should not contain /2 reads"
+    );
+    assert!(output2_content.contains("/2"), "R2 output should contain /2 reads");
+    assert!(
+        !output2_content.contains("/1"),
+        "R2 output should not contain /1 reads"
+    );
+}
+
+#[test]
+fn test_interleaved_rejects_second_input() {
+    let temp_dir = tempdir().unwrap();
+    let fasta_path = temp_dir.path().join("ref.fasta");
+    let fastq_path1 = temp_dir.path().join("reads_1.fastq");
+    let fastq_path2 = temp_dir.path().join("reads_2.fastq");
+    let bin_path = temp_dir.path().join("ref.bin");
+
+    create_test_fasta(&fasta_path);
+    create_test_paired_fastq(&fastq_path1, &fastq_path2);
+    build_index(&fasta_path, &bin_path);
+
+    let mut cmd = cargo::cargo_bin_cmd!("deacon");
+    cmd.arg("filter")
+        .arg("--interleaved")
+        .arg(&bin_path)
+        .arg(&fastq_path1)
+        .arg(&fastq_path2)
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "--interleaved cannot be used with a second input file",
+        ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add an explicit `--interleaved` flag so paired reads can be consumed from a single file path or stdin as one ordered stream
- preserve the existing paired-file behavior and the current `"- -"` stdin form as a non-breaking way to request interleaved processing
- allow interleaved input to write split paired outputs and add coverage for file-backed interleaved input and invalid CLI combinations

## Testing
- all tests pass locally