### PR TITLE
Fix zst output having incorrect finalizer

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1152,4 +1152,56 @@ mod tests {
         assert_eq!(parsed.output, "output.fastq");
         assert_eq!(parsed.output2, Some("output2.fastq".to_string()));
     }
+
+    // Decode a compressed file written by `get_writer`, picking the decoder from
+    // the extension. Returns an error (not a panic) on a truncated/invalid stream
+    // so the caller can assert a clean round-trip.
+    #[cfg(feature = "compression")]
+    fn decode_output(path: &std::path::Path) -> std::io::Result<Vec<u8>> {
+        use std::io::Read;
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        let file = std::fs::File::open(path)?;
+        let mut out = Vec::new();
+        match ext {
+            "gz" => flate2::read::MultiGzDecoder::new(file).read_to_end(&mut out)?,
+            "zst" => zstd::stream::read::Decoder::new(file)?.read_to_end(&mut out)?,
+            "xz" => liblzma::read::XzDecoder::new(file).read_to_end(&mut out)?,
+            _ => std::io::BufReader::new(file).read_to_end(&mut out)?,
+        };
+        Ok(out)
+    }
+
+    // Every output writer must finalize its stream when dropped, so the file
+    // round-trips cleanly. Regression test for truncated `.zst` output, where a
+    // bare zstd `Encoder` was dropped without writing the frame epilogue:
+    // https://github.com/bede/deacon/issues/88. Covers gz/zst/xz and the plain
+    // (uncompressed) path, each with a normal and an empty payload — an empty
+    // output must still be a valid, complete stream.
+    #[cfg(feature = "compression")]
+    #[rstest::rstest]
+    #[case("out.fq.gz")]
+    #[case("out.fq.zst")]
+    #[case("out.fq.xz")]
+    #[case("out.fq")]
+    fn test_output_stream_is_finalized(#[case] filename: &str) {
+        for payload in [
+            b"@read0\nACGTACGTACGT\n+\nIIIIIIIIIIII\n".to_vec(),
+            Vec::new(),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join(filename);
+
+            {
+                let mut writer = get_writer(Some(&path), 2, 1).unwrap();
+                writer.write_all(&payload).unwrap();
+                writer.flush().unwrap();
+                // `writer` dropped here: the stream must be finalized on drop.
+            }
+
+            let decoded = decode_output(&path).unwrap_or_else(|e| {
+                panic!("{filename} did not round-trip (truncated stream?): {e}")
+            });
+            assert_eq!(decoded, payload, "{filename} content mismatch");
+        }
+    }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -277,10 +277,14 @@ fn get_writer(
         #[cfg(feature = "compression")]
         p if p.ends_with(".zst") => {
             validate_compression_level(compression_level, 1, 22, "zstd")?;
-            Ok(Box::new(zstd::stream::write::Encoder::new(
-                buffered_file,
-                compression_level as i32,
-            )?))
+            // `auto_finish()` yields a writer that writes the zstd frame
+            // epilogue on drop. Without it, dropping a bare `Encoder` closes
+            // the file without finalizing the frame, producing a truncated
+            // `.zst` stream (`zstd -t` reports "premature end").
+            Ok(Box::new(
+                zstd::stream::write::Encoder::new(buffered_file, compression_level as i32)?
+                    .auto_finish(),
+            ))
         }
         #[cfg(feature = "compression")]
         p if p.ends_with(".xz") => {


### PR DESCRIPTION
### Add (failing) test reproducing #88 

Adds `test_output_stream_is_finalized`, an rstest-parametrized test that
round-trips normal and empty payloads through `get_writer` for every
output format (gz, zst, xz, plain) and asserts the bytes decode back
intact.

On the current code this fails for the `.zst` case with "incomplete
frame": a bare `zstd::stream::write::Encoder` is dropped without writing
the frame epilogue, truncating the stream. The gz/xz/plain cases pass,
confirming the defect is zstd-specific. See https://github.com/bede/deacon/issues/88.

The pre-existing `test_filter_to_file_zstd` missed this because it only
checked the output file was non-empty, never decoding it.

### fix: finalize zstd output frame with auto_finish()

The `.zst` writer boxed a bare `zstd::stream::write::Encoder`, which was
only dropped at the end of the filter run. Unlike the gzip (gzp) and xz
(liblzma) writers, a zstd `Encoder` does not write the end-of-frame
epilogue on drop, so `.zst` output was truncated: `zstd -t` reports
"premature end" and small outputs could lose all records.

Wrap the encoder in `.auto_finish()` so the epilogue is written when the
last `Arc<Mutex<_>>` reference drops, matching the existing drop-based
finalization flow. Both `-o` and `-O` outputs share `get_writer`, so the
paired-output path is fixed too.

Fixes https://github.com/bede/deacon/issues/88.
