### PR TITLE
BREAKING CHANGE: v0.16 -> CBQ input/output implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `deacon filter --ordered` uses paraseq 0.5.0 order preservation for deterministic output. Also exposed as `ordered` in the Python bindings and JSON summary.
+- `deacon filter` accepts CBQ (BINSEQ) input, detected automatically, and writes CBQ when the output path ends in `.cbq`; paired reads are stored as native paired records in a single file.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +167,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "binseq"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03ce47e3c043402933b71d00e26586b91f70d1cc237251097e2eb1ee9621d83"
+dependencies = [
+ "anyhow",
+ "auto_impl",
+ "bitnuc",
+ "bytemuck",
+ "byteorder",
+ "itoa",
+ "memchr",
+ "memmap2",
+ "num_cpus",
+ "rand 0.9.5",
+ "sucds",
+ "thiserror 2.0.18",
+ "zstd",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +198,12 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "bitnuc"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7871516cbb4e097e220623917e1491c995ee58c8018d929d4b1e76c378002bf"
 
 [[package]]
 name = "bstr"
@@ -186,9 +224,23 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"
@@ -249,7 +301,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -425,6 +477,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "bincode",
+ "binseq",
  "clap",
  "ensure_simd",
  "flate2",
@@ -716,7 +769,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -1008,9 +1061,18 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1120,7 +1182,7 @@ dependencies = [
  "cfg-if",
  "ensure_simd",
  "mem_dbg",
- "rand",
+ "rand 0.10.2",
  "wide",
 ]
 
@@ -1198,6 +1260,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -1372,13 +1443,42 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1795,6 +1895,16 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "sucds"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd324eaa05be64f105ea5269bb8aabd70e5dd57fa5c673b167f451b07d6c0dcd"
+dependencies = [
+ "anyhow",
+ "num-traits",
+]
 
 [[package]]
 name = "syn"
@@ -2270,6 +2380,26 @@ checksum = "45e820b97864028eb5069aabf2d90ad7bc279a0ed0292f1306451ce4b91adc13"
 dependencies = [
  "bincode",
  "libm",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ indicatif = { version = "0.18", optional = true }
 serde_json = { version = "1.0", optional = true }
 niffler = { version = "3.0.1", default-features = false, optional = true }
 paraseq = { version = "0.5.0", default-features = false, features = ["anyhow", "niffler"], optional = true }
+# Binary sequence format (CBQ) support. Defaults disabled: binseq's own paraseq integration is not needed.
+binseq = { version = "0.9.4", default-features = false, features = ["anyhow"], optional = true }
 ensure_simd = { version = "0.1.0", optional = true }
 
 # Compression deps (optional)
@@ -59,10 +61,11 @@ predicates = "3.0"
 tempfile = "3.20"
 rstest = "0.26"
 nix = { version = "0.31", features = ["fs"] }
+binseq = { version = "0.9.4", default-features = false, features = ["anyhow"] }
 
 [features]
 scalar = ["simd-minimizers/scalar", "packed-seq/scalar"]
-cli = ["rayon", "parking_lot", "indicatif", "paraseq", "ensure_simd", "clap", "niffler", "serde_json"]
+cli = ["rayon", "parking_lot", "indicatif", "paraseq", "binseq", "ensure_simd", "clap", "niffler", "serde_json"]
 # Disable for faster builds.
 compression = ["zstd", "liblzma", "flate2", "gzp", "paraseq/default"]
 # Use to still handle .gz files when "compression" is not enabled.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Prebuilt pangenome indexes are provided. These can be downloaded using the links
 
 ### Filtering
 
-The main command `deacon filter` accepts an index path followed by up to two FASTA/FASTQ file paths, depending on whether input sequences originate from stdin, a single file, or paired input files. Indexes are built with `deacon index build`.  Paired inputs are supported as either two separate or one interleaved file/stream when using `--interleaved`, and may be written either to separate paired output files or one interleaved file. For paired sequences, distinct minimizer hits originating from either mate are counted. By default, input sequences must meet both an absolute threshold of 2 minimizer hits (`-a 2`) and a relative threshold of 1% of minimizers (`-r 0.01`) to pass the filter. Filtering can be inverted for e.g. host depletion using the `--deplete` (`-d`) flag. Gzip, Zstandard, and xz compression formats are detected automatically by file extension. Paired read headers can be validated using `--check-pairs`. 
+The main command `deacon filter` accepts an index path followed by up to two FASTA/FASTQ file paths, depending on whether input sequences originate from stdin, a single file, or paired input files. Indexes are built with `deacon index build`.  Paired inputs are supported as either two separate or one interleaved file/stream when using `--interleaved`, and may be written either to separate paired output files or one interleaved file. For paired sequences, distinct minimizer hits originating from either mate are counted. By default, input sequences must meet both an absolute threshold of 2 minimizer hits (`-a 2`) and a relative threshold of 1% of minimizers (`-r 0.01`) to pass the filter. Filtering can be inverted for e.g. host depletion using the `--deplete` (`-d`) flag. Gzip, Zstandard, and xz compression formats are detected automatically by file extension. Paired read headers can be validated using `--check-pairs`. CBQ files (the columnar binary format of the [BINSEQ](https://www.biorxiv.org/content/10.1101/2025.04.08.647863v2) family) are detected on input by magic bytes, and written when the output path ends in `.cbq`; CBQ pairing is native, so paired reads stay in one file (do not pass `--output2`).
 
 #### Examples
 
@@ -129,6 +129,10 @@ zcat r12.fq.gz | deacon filter -d panhuman-1.k31w15.idx - - > filt12.fq
 
 # Save summary JSON
 deacon filter -d panhuman-1.k31w15.idx reads.fq.gz -o filt.fq.gz -s summary.json
+
+# CBQ (BINSEQ) input/output; paired reads stay in one CBQ file
+deacon filter panhuman-1.k31w15.idx reads.fq.gz -o filt.cbq
+deacon filter panhuman-1.k31w15.idx filt.cbq -o filt.fq.gz
 
 # Replace read headers with incrementing integers
 deacon filter -d -R panhuman-1.k31w15.idx reads.fq.gz > filt.fq

--- a/deacon-py/src/lib.rs
+++ b/deacon-py/src/lib.rs
@@ -160,7 +160,7 @@ impl Index {
         let mins = Arc::clone(&self.minimizers);
         let (k, w) = (self.k, self.w);
         let summary = py
-            .detach(|| run_with_index(&mins, &IndexHeader::new(k, w), &cfg))
+            .detach(|| run_with_index(mins, &IndexHeader::new(k, w), &cfg))
             .map_err(to_pyerr)?;
         Ok(pythonize::pythonize(py, &summary)?.unbind())
     }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -4,14 +4,18 @@ use crate::{
     MinimizerSet, validate_unit_interval,
 };
 use anyhow::{Context, Result};
+use binseq::cbq;
+use binseq::write::{BinseqWriterBuilder, Format as BinseqFormat};
+use binseq::{BinseqRecord, ParallelReader as BinseqParallelReader, SequencingRecordBuilder};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use paraseq::Record;
 use paraseq::fastx::Reader;
 use paraseq::parallel::{PairedParallelProcessor, ParallelProcessor, ParallelReader};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::fs::{File, OpenOptions};
-use std::io::{self, BufWriter, Write};
+use std::io::{self, BufWriter, Read, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -21,6 +25,118 @@ const OUTPUT_BUFFER_SIZE: usize = 8 * 1024 * 1024; // Opt: 8MB output buffer
 const DEFAULT_BUFFER_SIZE: usize = 64 * 1024;
 
 type BoxedWriter = Box<dyn Write + Send>;
+
+/// Input file format
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum InputFormat {
+    Fastx,
+    Cbq,
+}
+
+/// Output file format
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum OutputFormat {
+    Fastx,
+    Cbq,
+}
+
+/// Normalized input metadata, populated before any output is opened
+struct InputLayout {
+    format: InputFormat,
+    paired: bool,
+    qualities: bool,
+    headers: bool,
+}
+
+/// Shared output state; every processor clone merges into this under a lock
+#[derive(Clone)]
+enum SharedOutput {
+    Fastx(Arc<Mutex<BoxedWriter>>),
+    Cbq(Arc<Mutex<binseq::BinseqWriter<BoxedWriter>>>),
+}
+
+/// Thread-local output buffer merged into the shared output on batch completion
+#[allow(clippy::large_enum_variant)] // mirrors binseq's BinseqWriter, which is not boxed upstream
+#[derive(Clone)]
+enum LocalOutput {
+    Fastx(Vec<u8>),
+    Cbq(binseq::BinseqWriter<Vec<u8>>),
+}
+
+impl SharedOutput {
+    fn is_cbq(&self) -> bool {
+        matches!(self, Self::Cbq(_))
+    }
+}
+
+impl LocalOutput {
+    fn fastx_mut(&mut self) -> &mut Vec<u8> {
+        match self {
+            Self::Fastx(v) => v,
+            Self::Cbq(_) => unreachable!("CBQ local buffer used in FASTX path"),
+        }
+    }
+
+    fn fastx(&self) -> &[u8] {
+        match self {
+            Self::Fastx(v) => v,
+            Self::Cbq(_) => unreachable!("CBQ local buffer used in FASTX path"),
+        }
+    }
+
+    fn cbq_mut(&mut self) -> &mut binseq::BinseqWriter<Vec<u8>> {
+        match self {
+            Self::Cbq(w) => w,
+            Self::Fastx(_) => unreachable!("FASTX local buffer used in CBQ path"),
+        }
+    }
+}
+
+/// Input processing plan: every reader opens during layout resolution, before
+/// any output file is created.
+#[allow(clippy::large_enum_variant)] // MmapReader holds its mmap; boxed variants would add noise for no measurable gain
+enum InputPrep {
+    Cbq(cbq::MmapReader),
+    FastxSingle(Reader<Box<dyn std::io::Read + Send>>),
+    FastxInterleaved(Reader<Box<dyn std::io::Read + Send>>),
+    FastxPaired(
+        Reader<Box<dyn std::io::Read + Send>>,
+        Reader<Box<dyn std::io::Read + Send>>,
+    ),
+    /// Empty input: create empty output without processing
+    Empty,
+}
+
+/// Adapter exposing the primary/secondary halves of a CBQ record as paraseq records
+struct CbqRecord<'a> {
+    id: &'a [u8],
+    seq: &'a [u8],
+    qual: Option<&'a [u8]>,
+}
+
+impl Record for CbqRecord<'_> {
+    fn id(&self) -> &[u8] {
+        self.id
+    }
+
+    fn seq(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(self.seq)
+    }
+
+    fn seq_raw(&self) -> &[u8] {
+        self.seq
+    }
+
+    fn qual(&self) -> Option<&[u8]> {
+        self.qual
+    }
+
+    fn index(&self) -> u64 {
+        // ponytail: input position unknown for mmap'd CBQ records; unused by
+        // the filtering path (only paraseq's ordered machinery reads it), so 0.
+        0
+    }
+}
 
 /// Filtering config for an already-loaded index (no index path; see [`FilterConfig`]).
 pub struct FilterRunConfig {
@@ -213,6 +329,232 @@ struct PendingRename {
 /// Format a record into a buffer (FASTA/FASTQ), returning its line prefix
 /// `seq` is the newline-stripped sequence from `record.seq()`.
 /// When renaming, the header is left to [`write_renamed`].
+/// Resolve the output format from the output path suffix
+fn resolve_output_format(config: &FilterRunConfig) -> Result<OutputFormat> {
+    let Some(path) = config.output_path.as_deref() else {
+        return Ok(OutputFormat::Fastx);
+    };
+    let name = path.to_string_lossy();
+    if name.ends_with(".cbq") {
+        Ok(OutputFormat::Cbq)
+    } else if name.ends_with(".cbq.gz") || name.ends_with(".cbq.zst") || name.ends_with(".cbq.xz") {
+        anyhow::bail!(
+            "Compressed CBQ output is not supported (CBQ performs its own block compression): {}",
+            name
+        );
+    } else {
+        Ok(OutputFormat::Fastx)
+    }
+}
+
+/// Resolve the input format and layout, opening all readers up front so input
+/// errors surface before any output file is created.
+fn prepare_input(
+    config: &FilterRunConfig,
+    interleaved_input: bool,
+    output_format: OutputFormat,
+) -> Result<(InputLayout, InputPrep)> {
+    // ponytail: CBQ input is file-only so the mmap reader stays the only CBQ
+    // path; add binseq's streaming reader if stdin support is ever needed.
+    if config.input_path == "-" || is_special_input_path(&config.input_path) {
+        return prepare_fastx(config, interleaved_input, output_format);
+    }
+
+    // Regular files: sniff the CBQ magic; everything else is FASTX
+    let mut file = File::open(&config.input_path)
+        .map_err(|e| anyhow::anyhow!("Failed to open file {}: {}", config.input_path, e))?;
+    let mut magic = [0u8; 64];
+    let n = file.read(&mut magic)?;
+    match BinseqFormat::sniff(&magic[..n]) {
+        Some(BinseqFormat::Cbq) => {
+            match cbq::MmapReader::new(&config.input_path) {
+                Ok(reader) => {
+                    let header = reader.header();
+                    let layout = InputLayout {
+                        format: InputFormat::Cbq,
+                        paired: header.is_paired(),
+                        qualities: header.has_qualities(),
+                        headers: header.has_headers(),
+                    };
+                    Ok((layout, InputPrep::Cbq(reader)))
+                }
+                // binseq 0.9.4 cannot reopen zero-record CBQ files (its index
+                // cast fails on zero entries); treat them as valid empty inputs.
+                Err(binseq::Error::CbqError(binseq::error::CbqError::IndexCastingError))
+                    if n >= std::mem::size_of::<cbq::FileHeader>() =>
+                {
+                    let header = cbq::FileHeader::from_bytes(
+                        &magic[..std::mem::size_of::<cbq::FileHeader>()],
+                    )?;
+                    Ok((
+                        InputLayout {
+                            format: InputFormat::Cbq,
+                            paired: header.is_paired(),
+                            qualities: header.has_qualities(),
+                            headers: header.has_headers(),
+                        },
+                        InputPrep::Empty,
+                    ))
+                }
+                Err(e) => Err(e).context("Failed to open CBQ input"),
+            }
+        }
+        Some(f) => anyhow::bail!("{f:?} input is not supported; convert it to FASTQ or CBQ"),
+        None => prepare_fastx(config, interleaved_input, output_format),
+    }
+}
+
+/// Prepare a FASTX input: resolve the layout and open the reader(s) up front.
+fn prepare_fastx(
+    config: &FilterRunConfig,
+    interleaved_input: bool,
+    output_format: OutputFormat,
+) -> Result<(InputLayout, InputPrep)> {
+    let layout = InputLayout {
+        format: InputFormat::Fastx,
+        paired: interleaved_input || config.input2_path.is_some(),
+        qualities: false,
+        headers: true,
+    };
+
+    let input1_empty = is_empty_file(&config.input_path)?;
+    let input2_empty = config
+        .input2_path
+        .as_deref()
+        .map(is_empty_file)
+        .transpose()?
+        .unwrap_or(false);
+
+    if interleaved_input {
+        if input1_empty {
+            return Ok((layout, InputPrep::Empty));
+        }
+        return match create_paraseq_reader(Some(config.input_path.as_str())) {
+            Ok(reader) => {
+                let qualities = reader.format() == paraseq::fastx::Format::Fastq;
+                Ok((
+                    InputLayout {
+                        qualities,
+                        ..layout
+                    },
+                    InputPrep::FastxInterleaved(reader),
+                ))
+            }
+            Err(e) if is_empty_input_error(&e) => Ok((layout, InputPrep::Empty)),
+            Err(e) => Err(e),
+        };
+    }
+
+    if let Some(input2_path) = config.input2_path.as_deref() {
+        if input1_empty && input2_empty {
+            return Ok((layout, InputPrep::Empty));
+        }
+        if input1_empty || input2_empty {
+            return Err(anyhow::anyhow!(
+                "One paired file is empty but the other is not"
+            ));
+        }
+        let r1 = create_paraseq_reader(Some(config.input_path.as_str()));
+        let r2 = create_paraseq_reader(Some(input2_path));
+        return match (r1, r2) {
+            (Ok(reader1), Ok(reader2)) => {
+                if output_format == OutputFormat::Cbq
+                    && !config.output_fasta
+                    && reader1.format() != reader2.format()
+                {
+                    anyhow::bail!(
+                        "Mixed FASTA/FASTQ paired input cannot be written to a quality CBQ output"
+                    );
+                }
+                let qualities = reader1.format() == paraseq::fastx::Format::Fastq;
+                Ok((
+                    InputLayout {
+                        qualities,
+                        ..layout
+                    },
+                    InputPrep::FastxPaired(reader1, reader2),
+                ))
+            }
+            (Err(e1), Err(e2)) if is_empty_input_error(&e1) && is_empty_input_error(&e2) => {
+                Ok((layout, InputPrep::Empty))
+            }
+            (Err(e), _) if is_empty_input_error(&e) => Err(anyhow::anyhow!(
+                "First paired file appears empty while second is not"
+            )),
+            (_, Err(e)) if is_empty_input_error(&e) => Err(anyhow::anyhow!(
+                "Second paired file appears empty while first is not"
+            )),
+            (Err(e), _) => Err(e),
+            (_, Err(e)) => Err(e),
+        };
+    }
+
+    if input1_empty {
+        return Ok((layout, InputPrep::Empty));
+    }
+    match create_paraseq_reader(Some(config.input_path.as_str())) {
+        Ok(reader) => {
+            let qualities = reader.format() == paraseq::fastx::Format::Fastq;
+            Ok((
+                InputLayout {
+                    qualities,
+                    ..layout
+                },
+                InputPrep::FastxSingle(reader),
+            ))
+        }
+        Err(e) if is_empty_input_error(&e) => Ok((layout, InputPrep::Empty)),
+        Err(e) => Err(e),
+    }
+}
+
+/// Validate format combinations before any output file is opened or truncated
+fn validate_input_output(
+    layout: &InputLayout,
+    output_format: OutputFormat,
+    config: &FilterRunConfig,
+) -> Result<()> {
+    if layout.format == InputFormat::Cbq && config.input2_path.is_some() {
+        anyhow::bail!("CBQ input does not support INPUT2");
+    }
+    if layout.format == InputFormat::Cbq && config.interleaved {
+        anyhow::bail!("CBQ input does not support --interleaved");
+    }
+    if output_format == OutputFormat::Cbq && config.output2_path.is_some() {
+        anyhow::bail!("CBQ output does not support OUTPUT2; CBQ pairing is native");
+    }
+    if output_format == OutputFormat::Cbq && config.output_path.is_none() {
+        anyhow::bail!("CBQ output to stdout is not supported");
+    }
+    if config.check_pairs && layout.format == InputFormat::Cbq && !layout.headers {
+        anyhow::bail!("--check-pairs requires CBQ input with headers");
+    }
+    validate_check_pairs_mode(config.check_pairs, layout.paired)?;
+    Ok(())
+}
+
+/// Renamed or original header for a record. Renamed headers are
+/// `counter[+ suffix]`, matching the existing FASTX output.
+fn record_header<'a>(
+    id: &'a [u8],
+    counter: u64,
+    rename: bool,
+    read_suffix: &[u8],
+) -> Cow<'a, [u8]> {
+    if rename {
+        let mut header = counter.to_string().into_bytes();
+        if !read_suffix.is_empty() {
+            header.push(b' ');
+            header.extend_from_slice(read_suffix);
+        }
+        Cow::Owned(header)
+    } else {
+        Cow::Borrowed(id)
+    }
+}
+
+/// Format a single record into a buffer (FASTA/FASTQ format)
+/// `seq` is the newline-stripped sequence corresponding to the record from `record.seq()`.
 fn format_record_to_buffer<R: Record>(
     record: &R,
     seq: &[u8],
@@ -405,9 +747,9 @@ pub struct FilterSummary {
 }
 
 #[derive(Clone)]
-struct FilterProcessor<'a> {
+struct FilterProcessor {
     // Minimizer matching parameters
-    minimizers: &'a MinimizerSet,
+    minimizers: Arc<MinimizerSet>,
     rename: bool,
     output_fasta: bool,
     debug: bool,
@@ -417,8 +759,8 @@ struct FilterProcessor<'a> {
     kernel: FilterKernel,
 
     // Local buffers
-    local_buffer: Vec<u8>,
-    local_buffer2: Vec<u8>, // Second buffer for paired output
+    local_buffer: LocalOutput,
+    local_buffer2: Vec<u8>, // Second buffer for paired FASTX output
     local_stats: ProcessingStats,
 
     // Headers awaiting a number, and how many records/pairs this batch kept
@@ -429,7 +771,7 @@ struct FilterProcessor<'a> {
     rename_counter: Arc<AtomicU64>,
 
     // Global state
-    global_writer: Arc<Mutex<BoxedWriter>>,
+    global_writer: SharedOutput,
     global_writer2: Option<Arc<Mutex<BoxedWriter>>>,
     global_stats: Arc<Mutex<ProcessingStats>>,
     spinner: Option<Arc<Mutex<ProgressBar>>>,
@@ -446,17 +788,21 @@ pub(crate) struct ProcessingStats {
     pub last_reported: u64,
 }
 
-impl<'a> FilterProcessor<'a> {
+impl FilterProcessor {
     fn new(
-        minimizers: &'a MinimizerSet,
+        minimizers: Arc<MinimizerSet>,
         kmer_length: u8,
         window_size: u8,
         config: &FilterProcessorConfig,
-        writer: BoxedWriter,
+        global_writer: SharedOutput,
         writer2: Option<BoxedWriter>,
         spinner: Option<Arc<Mutex<ProgressBar>>>,
         filtering_start_time: Instant,
     ) -> Result<Self> {
+        let local_buffer = match &global_writer {
+            SharedOutput::Cbq(writer) => LocalOutput::Cbq(writer.lock().new_headless_buffer()?),
+            SharedOutput::Fastx(_) => LocalOutput::Fastx(Vec::with_capacity(DEFAULT_BUFFER_SIZE)),
+        };
         Ok(Self {
             minimizers,
             rename: config.rename,
@@ -474,14 +820,14 @@ impl<'a> FilterProcessor<'a> {
                     prefix_length: config.prefix_length,
                 },
             )?,
-            local_buffer: Vec::with_capacity(DEFAULT_BUFFER_SIZE),
+            local_buffer,
             local_buffer2: Vec::with_capacity(DEFAULT_BUFFER_SIZE),
             pending_renames: Vec::new(),
             pending_renames2: Vec::new(),
             batch_kept: 0,
             local_stats: ProcessingStats::default(),
             rename_counter: Arc::new(AtomicU64::new(0)),
-            global_writer: Arc::new(Mutex::new(writer)),
+            global_writer,
             global_writer2: writer2.map(|w| Arc::new(Mutex::new(w))),
             global_stats: Arc::new(Mutex::new(ProcessingStats::default())),
             spinner,
@@ -490,12 +836,12 @@ impl<'a> FilterProcessor<'a> {
     }
 
     fn should_keep_sequence(&mut self, seq: &[u8]) -> FilterDecision {
-        self.kernel.classify_read(self.minimizers, seq, self.debug)
+        self.kernel.classify_read(&self.minimizers, seq, self.debug)
     }
 
     fn should_keep_pair(&mut self, seq1: &[u8], seq2: &[u8]) -> FilterDecision {
         self.kernel
-            .classify_pair(self.minimizers, seq1, seq2, self.debug)
+            .classify_pair(&self.minimizers, seq1, seq2, self.debug)
     }
 
     fn write_record<Rf: Record>(
@@ -504,13 +850,21 @@ impl<'a> FilterProcessor<'a> {
         seq: &[u8],
         read_suffix: &'static [u8],
     ) -> Result<()> {
-        let offset = self.local_buffer.len();
+        if self.global_writer.is_cbq() {
+            let counter = if self.rename {
+                self.rename_counter.fetch_add(1, Ordering::Relaxed) + 1
+            } else {
+                0
+            };
+            return self.push_cbq(record, seq, counter, read_suffix);
+        }
+        let offset = self.local_buffer.fastx().len();
         let marker = format_record_to_buffer(
             record,
             seq,
             self.rename,
             self.output_fasta,
-            &mut self.local_buffer,
+            self.local_buffer.fastx_mut(),
         )?;
         if self.rename {
             self.pending_renames.push(PendingRename {
@@ -558,6 +912,47 @@ impl<'a> FilterProcessor<'a> {
             + 1
     }
 
+    /// Push a single record into the thread-local CBQ writer
+    fn push_cbq<Rf: Record>(
+        &mut self,
+        record: &Rf,
+        seq: &[u8],
+        counter: u64,
+        read_suffix: &[u8],
+    ) -> Result<()> {
+        let header = record_header(record.id(), counter, self.rename, read_suffix);
+        let seq_record = SequencingRecordBuilder::default()
+            .s_seq(seq)
+            .s_header(&header)
+            .opt_s_qual(record.qual())
+            .build()?;
+        self.local_buffer.cbq_mut().push(seq_record)?;
+        Ok(())
+    }
+
+    /// Push a paired record (both mates) into the thread-local CBQ writer
+    fn push_cbq_pair<Rf: Record>(
+        &mut self,
+        record1: &Rf,
+        seq1: &[u8],
+        record2: &Rf,
+        seq2: &[u8],
+        counter: u64,
+    ) -> Result<()> {
+        let header1 = record_header(record1.id(), counter, self.rename, b"/1");
+        let header2 = record_header(record2.id(), counter, self.rename, b"/2");
+        let seq_record = SequencingRecordBuilder::default()
+            .s_seq(seq1)
+            .s_header(&header1)
+            .opt_s_qual(record1.qual())
+            .x_seq(seq2)
+            .x_header(&header2)
+            .opt_x_qual(record2.qual())
+            .build()?;
+        self.local_buffer.cbq_mut().push(seq_record)?;
+        Ok(())
+    }
+
     fn update_spinner(&self) {
         if let Some(ref spinner) = self.spinner {
             let stats = self.global_stats.lock();
@@ -592,14 +987,9 @@ impl<'a> FilterProcessor<'a> {
             ));
         }
     }
-}
 
-impl<'a, Rf: Record> ParallelProcessor<Rf> for FilterProcessor<'a> {
-    fn requires_ordering(&self) -> bool {
-        self.ordered
-    }
-
-    fn process_record(&mut self, record: Rf) -> paraseq::parallel::Result<()> {
+    /// Shared per-record logic for every reader (paraseq FASTX, CBQ mmap, ...)
+    fn handle_record<Rf: Record>(&mut self, record: &Rf) -> Result<()> {
         let seq = record.seq();
         self.local_stats.total_seqs += 1;
         self.local_stats.total_bp += seq.len() as u64;
@@ -620,7 +1010,7 @@ impl<'a, Rf: Record> ParallelProcessor<Rf> for FilterProcessor<'a> {
 
         if decision.keep {
             self.local_stats.output_bp += seq.len() as u64;
-            self.write_record(&record, &seq, b"")?;
+            self.write_record(record, &seq, b"")?;
             if self.rename {
                 self.batch_kept += 1;
             }
@@ -632,62 +1022,14 @@ impl<'a, Rf: Record> ParallelProcessor<Rf> for FilterProcessor<'a> {
         Ok(())
     }
 
-    fn on_batch_complete(&mut self) -> paraseq::parallel::Result<()> {
-        // Write buffer to output
-        if !self.local_buffer.is_empty() {
-            let mut global_writer = self.global_writer.lock();
-            if self.rename {
-                let base = self.reserve_rename_ids();
-                write_renamed(
-                    &mut global_writer,
-                    &self.local_buffer,
-                    &self.pending_renames,
-                    base,
-                )?;
-            } else {
-                global_writer.write_all(&self.local_buffer)?;
-            }
-            global_writer.flush()?;
-        }
-
-        // Clear buffer after releasing the lock
-        self.local_buffer.clear();
-        self.pending_renames.clear();
-        self.batch_kept = 0;
-
-        // Update global stats
-        {
-            let mut stats = self.global_stats.lock();
-            stats.total_seqs += self.local_stats.total_seqs;
-            stats.filtered_seqs += self.local_stats.filtered_seqs;
-            stats.total_bp += self.local_stats.total_bp;
-            stats.output_bp += self.local_stats.output_bp;
-            stats.filtered_bp += self.local_stats.filtered_bp;
-        }
-
-        // Update spinner
-        self.update_spinner();
-
-        // Reset local stats
-        self.local_stats = ProcessingStats::default();
-
-        Ok(())
-    }
-}
-
-impl<'a, Rf: Record> PairedParallelProcessor<Rf> for FilterProcessor<'a> {
-    fn requires_ordering(&self) -> bool {
-        self.ordered
-    }
-
-    fn process_record_pair(&mut self, record1: Rf, record2: Rf) -> paraseq::parallel::Result<()> {
+    /// Shared per-pair logic for every reader (paraseq FASTX, CBQ mmap, ...)
+    fn handle_record_pair<Rf: Record>(&mut self, record1: &Rf, record2: &Rf) -> Result<()> {
         if self.check_pairs && !paired_record_names_match(record1.id(), record2.id()) {
             return Err(anyhow::anyhow!(
                 "Paired record name mismatch: R1='{}', R2='{}'. Expected matching Illumina CASAVA 1: and 2: fields or names suffixed with /1 and /2",
                 String::from_utf8_lossy(record1.id()),
                 String::from_utf8_lossy(record2.id())
-            )
-            .into());
+            ));
         }
 
         let seq1 = record1.seq();
@@ -714,14 +1056,22 @@ impl<'a, Rf: Record> PairedParallelProcessor<Rf> for FilterProcessor<'a> {
         if decision.keep {
             self.local_stats.output_bp += (seq1.len() + seq2.len()) as u64;
             // Both mates take the pair's number
-            if self.global_writer2.is_some() {
+            if self.global_writer.is_cbq() {
+                // Native paired record: both mates in one CBQ record
+                let counter = if self.rename {
+                    self.rename_counter.fetch_add(1, Ordering::Relaxed) + 1
+                } else {
+                    0
+                };
+                self.push_cbq_pair(record1, &seq1, record2, &seq2, counter)?;
+            } else if self.global_writer2.is_some() {
                 // Separate outputs
-                self.write_record(&record1, &seq1, b"/1")?;
-                self.write_record_to_buffer2(&record2, &seq2, b"/2")?;
+                self.write_record(record1, &seq1, b"/1")?;
+                self.write_record_to_buffer2(record2, &seq2, b"/2")?;
             } else {
                 // Interleaved output
-                self.write_record(&record1, &seq1, b"/1")?;
-                self.write_record(&record2, &seq2, b"/2")?;
+                self.write_record(record1, &seq1, b"/1")?;
+                self.write_record(record2, &seq2, b"/2")?;
             }
             if self.rename {
                 self.batch_kept += 1;
@@ -734,51 +1084,67 @@ impl<'a, Rf: Record> PairedParallelProcessor<Rf> for FilterProcessor<'a> {
         Ok(())
     }
 
-    fn on_batch_complete(&mut self) -> paraseq::parallel::Result<()> {
-        if let Some(ref writer2) = self.global_writer2 {
-            // Atomic paired batch writing
-            if !self.local_buffer.is_empty() || !self.local_buffer2.is_empty() {
-                let mut writer1 = self.global_writer.lock();
-                let mut writer2 = writer2.lock();
-
-                if self.rename {
-                    // Both mates share one block of numbers
-                    let base = self.reserve_rename_ids();
-                    write_renamed(
-                        &mut writer1,
-                        &self.local_buffer,
-                        &self.pending_renames,
-                        base,
-                    )?;
-                    write_renamed(
-                        &mut writer2,
-                        &self.local_buffer2,
-                        &self.pending_renames2,
-                        base,
-                    )?;
-                } else {
-                    writer1.write_all(&self.local_buffer)?;
-                    writer2.write_all(&self.local_buffer2)?;
-                }
-                writer1.flush()?;
-                writer2.flush()?;
+    /// Merge thread-local buffers and stats into the shared state (per batch)
+    fn flush_batch(&mut self) -> Result<()> {
+        match &self.global_writer {
+            SharedOutput::Cbq(global) => {
+                global
+                    .lock()
+                    .ingest_completed(self.local_buffer.cbq_mut())?;
             }
-        } else {
-            // Interleaved output
-            if !self.local_buffer.is_empty() {
-                let mut writer = self.global_writer.lock();
-                if self.rename {
-                    let base = self.reserve_rename_ids();
-                    write_renamed(&mut writer, &self.local_buffer, &self.pending_renames, base)?;
+            SharedOutput::Fastx(global) => {
+                if let Some(writer2) = &self.global_writer2 {
+                    // Atomic paired batch writing
+                    if !self.local_buffer.fastx().is_empty() || !self.local_buffer2.is_empty() {
+                        let mut writer1 = global.lock();
+                        let mut writer2 = writer2.lock();
+
+                        if self.rename {
+                            // Both mates share one block of numbers
+                            let base = self.reserve_rename_ids();
+                            write_renamed(
+                                &mut writer1,
+                                self.local_buffer.fastx(),
+                                &self.pending_renames,
+                                base,
+                            )?;
+                            write_renamed(
+                                &mut writer2,
+                                &self.local_buffer2,
+                                &self.pending_renames2,
+                                base,
+                            )?;
+                        } else {
+                            writer1.write_all(self.local_buffer.fastx())?;
+                            writer2.write_all(&self.local_buffer2)?;
+                        }
+                        writer1.flush()?;
+                        writer2.flush()?;
+                    }
                 } else {
-                    writer.write_all(&self.local_buffer)?;
+                    // Interleaved output
+                    if !self.local_buffer.fastx().is_empty() {
+                        let mut writer = global.lock();
+                        if self.rename {
+                            let base = self.reserve_rename_ids();
+                            write_renamed(
+                                &mut writer,
+                                self.local_buffer.fastx(),
+                                &self.pending_renames,
+                                base,
+                            )?;
+                        } else {
+                            writer.write_all(self.local_buffer.fastx())?;
+                        }
+                        writer.flush()?;
+                    }
                 }
-                writer.flush()?;
             }
         }
 
-        // Clear buffer after releasing the lock for better performance
-        self.local_buffer.clear();
+        if let LocalOutput::Fastx(v) = &mut self.local_buffer {
+            v.clear();
+        }
         self.local_buffer2.clear();
         self.pending_renames.clear();
         self.pending_renames2.clear();
@@ -800,6 +1166,92 @@ impl<'a, Rf: Record> PairedParallelProcessor<Rf> for FilterProcessor<'a> {
         // Reset local stats
         self.local_stats = ProcessingStats::default();
 
+        Ok(())
+    }
+
+    /// Merge any remaining local blocks into the shared state (per thread)
+    fn flush_thread(&mut self) -> Result<()> {
+        if let SharedOutput::Cbq(global) = &self.global_writer {
+            global.lock().ingest(self.local_buffer.cbq_mut())?;
+        }
+        Ok(())
+    }
+}
+
+impl<Rf: Record> ParallelProcessor<Rf> for FilterProcessor {
+    fn requires_ordering(&self) -> bool {
+        self.ordered
+    }
+
+    fn process_record(&mut self, record: Rf) -> paraseq::parallel::Result<()> {
+        self.handle_record(&record)?;
+        Ok(())
+    }
+
+    fn on_batch_complete(&mut self) -> paraseq::parallel::Result<()> {
+        self.flush_batch()?;
+        Ok(())
+    }
+
+    fn on_thread_complete(&mut self) -> paraseq::parallel::Result<()> {
+        self.flush_thread()?;
+        Ok(())
+    }
+}
+
+impl<Rf: Record> PairedParallelProcessor<Rf> for FilterProcessor {
+    fn requires_ordering(&self) -> bool {
+        self.ordered
+    }
+
+    fn process_record_pair(&mut self, record1: Rf, record2: Rf) -> paraseq::parallel::Result<()> {
+        self.handle_record_pair(&record1, &record2)?;
+        Ok(())
+    }
+
+    fn on_batch_complete(&mut self) -> paraseq::parallel::Result<()> {
+        self.flush_batch()?;
+        Ok(())
+    }
+
+    fn on_thread_complete(&mut self) -> paraseq::parallel::Result<()> {
+        self.flush_thread()?;
+        Ok(())
+    }
+}
+
+impl binseq::ParallelProcessor for FilterProcessor {
+    fn process_record<R: BinseqRecord>(&mut self, record: R) -> binseq::Result<()> {
+        if record.is_paired() {
+            let record1 = CbqRecord {
+                id: record.sheader(),
+                seq: record.sseq(),
+                qual: record.has_quality().then(|| record.squal()),
+            };
+            let record2 = CbqRecord {
+                id: record.xheader(),
+                seq: record.xseq(),
+                qual: record.has_quality().then(|| record.xqual()),
+            };
+            self.handle_record_pair(&record1, &record2)?;
+        } else {
+            let record1 = CbqRecord {
+                id: record.sheader(),
+                seq: record.sseq(),
+                qual: record.has_quality().then(|| record.squal()),
+            };
+            self.handle_record(&record1)?;
+        }
+        Ok(())
+    }
+
+    fn on_batch_complete(&mut self) -> binseq::Result<()> {
+        self.flush_batch()?;
+        Ok(())
+    }
+
+    fn on_thread_complete(&mut self) -> binseq::Result<()> {
+        self.flush_thread()?;
         Ok(())
     }
 }
@@ -874,7 +1326,7 @@ pub fn run(config: &FilterConfig) -> Result<FilterSummary> {
                 threshold
             );
         }
-        return run_with_index(&minimizers, &header, &run_config);
+        return run_with_index(Arc::new(minimizers), &header, &run_config);
     }
 
     let (minimizers, header) = load_minimizers_cached(config.minimizers_path)?;
@@ -895,7 +1347,7 @@ pub fn run(config: &FilterConfig) -> Result<FilterSummary> {
 /// Reusable entry point behind the Python bindings... load the index once, call repeatedly.
 /// Does no index-path validation; the index is already in memory.
 pub fn run_with_index(
-    minimizers: &MinimizerSet,
+    minimizers: Arc<MinimizerSet>,
     header: &IndexHeader,
     config: &FilterRunConfig,
 ) -> Result<FilterSummary> {
@@ -950,15 +1402,22 @@ pub fn run_with_index(
             .context("Failed to initialize thread pool");
     }
 
+    check_input_paths(config)?;
+
+    // Resolve formats and input metadata before opening or truncating outputs
+    let interleaved_stdin = config.input_path == "-" && config.input2_path.as_deref() == Some("-");
+    let interleaved_input = config.interleaved || interleaved_stdin;
+    let output_format = resolve_output_format(config)?;
+    let (layout, prepared) = prepare_input(config, interleaved_input, output_format)?;
+    validate_input_output(&layout, output_format, config)?;
+
     let mode = if config.deplete { "deplete" } else { "search" };
 
     let mut input_type = String::new();
     let mut options = Vec::<String>::new();
-    let interleaved_stdin = config.input_path == "-" && config.input2_path.as_deref() == Some("-");
-    let interleaved_input = config.interleaved || interleaved_stdin;
     if interleaved_input {
         input_type.push_str("interleaved");
-    } else if config.input2_path.is_some() {
+    } else if layout.paired {
         input_type.push_str("paired");
     } else {
         input_type.push_str("single");
@@ -1003,25 +1462,42 @@ pub fn run_with_index(
         );
     }
 
-    check_input_paths(config)?;
-
-    let writer = get_writer(
-        config.output_path.as_deref(),
-        config.compression_level,
-        compression_threads_per_output,
-    )?;
-    let writer2 = if let Some(output2) = config.output2_path.as_deref() {
-        if config.input2_path.is_some() || interleaved_input {
-            Some(get_writer(
-                Some(std::path::Path::new(output2)),
+    let (global_writer, writer2) = match output_format {
+        OutputFormat::Cbq => {
+            let cbq_writer = BinseqWriterBuilder::new(BinseqFormat::Cbq)
+                .paired(layout.paired)
+                .quality(layout.qualities && !config.output_fasta)
+                .headers(layout.headers || config.rename)
+                .flags(false)
+                .build(get_writer(
+                    config.output_path.as_deref(),
+                    config.compression_level,
+                    compression_threads_per_output,
+                )?)
+                .context("Failed to create CBQ writer")?;
+            (SharedOutput::Cbq(Arc::new(Mutex::new(cbq_writer))), None)
+        }
+        OutputFormat::Fastx => {
+            let writer = get_writer(
+                config.output_path.as_deref(),
                 config.compression_level,
                 compression_threads_per_output,
-            )?)
-        } else {
-            None
+            )?;
+            let writer2 = if let Some(output2) = config.output2_path.as_deref() {
+                if layout.paired {
+                    Some(get_writer(
+                        Some(std::path::Path::new(output2)),
+                        config.compression_level,
+                        compression_threads_per_output,
+                    )?)
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+            (SharedOutput::Fastx(Arc::new(Mutex::new(writer))), writer2)
         }
-    } else {
-        None
     };
 
     // Progress bar setup if not quiet
@@ -1057,99 +1533,31 @@ pub fn run_with_index(
         kmer_length,
         window_size,
         &processor_config,
-        writer,
+        global_writer,
         writer2,
         spinner.clone(),
         filtering_start_time,
     )?;
 
-    // Check for empty files via metadata (fast path for uncompressed files <5 bytes)
-    let input1_empty = is_empty_file(&config.input_path)?;
-    let input2_empty = config
-        .input2_path
-        .as_deref()
-        .map(is_empty_file)
-        .transpose()?
-        .unwrap_or(false);
-
     // Process based on input type - use filtering threads (already calculated above)
     let num_threads = filtering_threads;
 
-    if interleaved_input {
-        // Interleaved paired input from stdin or a file
-        if input1_empty {
-            if !quiet {
-                eprintln!("Empty input file(s) detected");
-            }
-        } else {
-            match create_paraseq_reader(Some(config.input_path.as_str())) {
-                Ok(reader) => {
-                    reader.process_parallel_interleaved(&mut processor, num_threads)?;
-                }
-                Err(e) if is_empty_input_error(&e) => {
-                    if !quiet {
-                        eprintln!("Empty input file(s) detected");
-                    }
-                }
-                Err(e) => return Err(e),
-            }
+    match prepared {
+        InputPrep::Cbq(reader) => {
+            reader.process_parallel(processor.clone(), num_threads)?;
         }
-    } else if let Some(input2_path) = config.input2_path.as_deref() {
-        // Paired files - both must be empty or both non-empty
-        if input1_empty && input2_empty {
-            if !quiet {
-                eprintln!("Empty input file(s) detected");
-            }
-        } else if input1_empty || input2_empty {
-            return Err(anyhow::anyhow!(
-                "One paired file is empty but the other is not"
-            ));
-        } else {
-            // Try to create readers, catching empty compressed files
-            let r1_result = create_paraseq_reader(Some(config.input_path.as_str()));
-            let r2_result = create_paraseq_reader(Some(input2_path));
-
-            match (r1_result, r2_result) {
-                (Ok(r1), Ok(r2)) => {
-                    r1.process_parallel_paired(r2, &mut processor, num_threads)?;
-                }
-                (Err(e1), Err(e2)) if is_empty_input_error(&e1) && is_empty_input_error(&e2) => {
-                    if !quiet {
-                        eprintln!("Empty input file(s) detected");
-                    }
-                }
-                (Err(e), _) if is_empty_input_error(&e) => {
-                    return Err(anyhow::anyhow!(
-                        "First paired file appears empty while second is not"
-                    ));
-                }
-                (_, Err(e)) if is_empty_input_error(&e) => {
-                    return Err(anyhow::anyhow!(
-                        "Second paired file appears empty while first is not"
-                    ));
-                }
-                (Err(e), _) => return Err(e),
-                (_, Err(e)) => return Err(e),
-            }
+        InputPrep::FastxSingle(reader) => {
+            reader.process_parallel(&mut processor, num_threads)?;
         }
-    } else {
-        // Single file or stdin
-        if input1_empty {
+        InputPrep::FastxInterleaved(reader) => {
+            reader.process_parallel_interleaved(&mut processor, num_threads)?;
+        }
+        InputPrep::FastxPaired(reader1, reader2) => {
+            reader1.process_parallel_paired(reader2, &mut processor, num_threads)?;
+        }
+        InputPrep::Empty => {
             if !quiet {
                 eprintln!("Empty input file(s) detected");
-            }
-        } else {
-            // Try to create reader, catching empty compressed files
-            match create_paraseq_reader(Some(config.input_path.as_str())) {
-                Ok(reader) => {
-                    reader.process_parallel(&mut processor, num_threads)?;
-                }
-                Err(e) if is_empty_input_error(&e) => {
-                    if !quiet {
-                        eprintln!("Empty input file(s) detected");
-                    }
-                }
-                Err(e) => return Err(e),
             }
         }
     }
@@ -1162,6 +1570,11 @@ pub fn run_with_index(
     let filtered_bp = final_stats.filtered_bp;
 
     drop(final_stats); // Release lock
+
+    // Finish the CBQ stream: flush remaining blocks and write the embedded index
+    if let SharedOutput::Cbq(global) = &processor.global_writer {
+        global.lock().finish()?;
+    }
 
     // Flush writers - they should auto-flush on drop
     drop(processor.global_writer);

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -354,7 +354,7 @@ fn prepare_input(
     interleaved_input: bool,
     output_format: OutputFormat,
 ) -> Result<(InputLayout, InputPrep)> {
-    // ponytail: CBQ input is file-only so the mmap reader stays the only CBQ
+    // CBQ input is file-only so the mmap reader stays the only CBQ
     // path; add binseq's streaming reader if stdin support is ever needed.
     if config.input_path == "-" || is_special_input_path(&config.input_path) {
         return prepare_fastx(config, interleaved_input, output_format);

--- a/src/index.rs
+++ b/src/index.rs
@@ -167,7 +167,7 @@ pub fn load_header_and_count<P: AsRef<Path>>(path: &P) -> Result<(IndexHeader, u
 }
 
 #[cfg(feature = "cli")]
-static INDEX: OnceLock<(PathBuf, crate::MinimizerSet, IndexHeader)> = OnceLock::new();
+static INDEX: OnceLock<(PathBuf, Arc<crate::MinimizerSet>, IndexHeader)> = OnceLock::new();
 
 #[cfg(feature = "cli")]
 pub fn current_index_path() -> Option<PathBuf> {
@@ -177,18 +177,18 @@ pub fn current_index_path() -> Option<PathBuf> {
 #[cfg(feature = "cli")]
 pub fn load_minimizers_cached(
     path: &Path,
-) -> Result<(&'static crate::MinimizerSet, &'static IndexHeader)> {
+) -> Result<(Arc<crate::MinimizerSet>, &'static IndexHeader)> {
     let (p, minimizers, header) = INDEX.get_or_init(|| {
         // Auto-detect exact vs BFF format
         let (m, h) = load_index_from_path_auto(path).unwrap();
-        (path.to_owned(), m, h)
+        (path.to_owned(), Arc::new(m), h)
     });
     assert_eq!(
         p, path,
         "Currently, the server can only have one index loaded."
     );
 
-    Ok((minimizers, header))
+    Ok((Arc::clone(minimizers), header))
 }
 
 /// Load minimizers from a reader (generic over any Read impl)

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,11 +34,11 @@ enum Command {
         /// Path to minimizer index file
         index: PathBuf,
 
-        /// Optional path to fastx file (or - for stdin)
+        /// Optional path to fastx or CBQ file (or - for stdin)
         #[arg(default_value = "-")]
         input: String,
 
-        /// Optional path to second paired fastx file
+        /// Optional path to second paired fastx file (not supported with CBQ input)
         input2: Option<String>,
 
         /// Minimum absolute number of minimizer hits for a match
@@ -69,11 +69,11 @@ enum Command {
         #[arg(short = 'f', long = "fasta", default_value_t = false)]
         output_fasta: bool,
 
-        /// Path to output fastx file (stdout if not specified; detects .gz and .zst)
+        /// Path to output fastx file (stdout if not specified; detects .gz and .zst; .cbq suffix writes CBQ)
         #[arg(short = 'o', long = "output")]
         output: Option<PathBuf>,
 
-        /// Optional path to second paired output fastx file (detects .gz and .zst)
+        /// Optional path to second paired output fastx file (detects .gz and .zst; not supported with CBQ output)
         #[arg(short = 'O', long = "output2")]
         output2: Option<String>,
 

--- a/tests/filter_tests.rs
+++ b/tests/filter_tests.rs
@@ -2783,3 +2783,294 @@ fn test_filter_paired_deplete_with_rename() {
         );
     }
 }
+
+/// Write a small paired, headerless, quality-free CBQ file for validation tests
+fn write_headerless_paired_cbq(path: &Path) {
+    use binseq::SequencingRecordBuilder;
+    use binseq::write::{BinseqWriterBuilder, Format};
+    let file = File::create(path).unwrap();
+    let mut writer = BinseqWriterBuilder::new(Format::Cbq)
+        .paired(true)
+        .build(file)
+        .unwrap();
+    for seq in [
+        b"ACGTACGTACGTACGTACGT".as_slice(),
+        b"TGCAACGTACGTACGTACGT".as_slice(),
+    ] {
+        writer
+            .push(
+                SequencingRecordBuilder::default()
+                    .s_seq(seq)
+                    .x_seq(seq)
+                    .build()
+                    .unwrap(),
+            )
+            .unwrap();
+    }
+    writer.finish().unwrap();
+}
+
+/// CBQ is only an I/O concern: FASTX -> CBQ -> FASTX must preserve reads,
+/// pairing, headers, qualities, and summary counts exactly.
+#[test]
+fn cbq_roundtrip_matches_fastx() {
+    let temp_dir = tempdir().unwrap();
+    let fasta_path = temp_dir.path().join("ref.fasta");
+    let bin_path = temp_dir.path().join("ref.bin");
+    let fastq_path = temp_dir.path().join("reads.fastq");
+    let r1_path = temp_dir.path().join("reads_1.fastq");
+    let r2_path = temp_dir.path().join("reads_2.fastq");
+
+    create_test_fasta(&fasta_path);
+    create_test_fastq(&fastq_path);
+    create_test_paired_fastq(&r1_path, &r2_path);
+    build_index(&fasta_path, &bin_path);
+
+    // Single-end: FASTQ -> FASTQ baseline vs FASTQ -> CBQ
+    let baseline = temp_dir.path().join("baseline.fastq");
+    let cbq_path = temp_dir.path().join("reads.cbq");
+    let summary1 = temp_dir.path().join("summary1.json");
+    let summary2 = temp_dir.path().join("summary2.json");
+
+    cargo::cargo_bin_cmd!("deacon")
+        .args(["filter", "-a", "1", "-r", "0.0", "-t", "1"])
+        .arg(&bin_path)
+        .arg(&fastq_path)
+        .arg("--output")
+        .arg(&baseline)
+        .arg("--summary")
+        .arg(&summary1)
+        .assert()
+        .success();
+    cargo::cargo_bin_cmd!("deacon")
+        .args(["filter", "-a", "1", "-r", "0.0", "-t", "1"])
+        .arg(&bin_path)
+        .arg(&fastq_path)
+        .arg("--output")
+        .arg(&cbq_path)
+        .arg("--summary")
+        .arg(&summary2)
+        .assert()
+        .success();
+
+    let baseline_content = fs::read_to_string(&baseline).unwrap();
+    assert_eq!(count_records(&baseline_content), 2);
+
+    // The CBQ itself: single, with headers and qualities, same record count
+    let reader = binseq::cbq::MmapReader::new(&cbq_path).unwrap();
+    assert!(!reader.is_paired(), "single-end CBQ must be unpaired");
+    assert!(reader.header().has_headers(), "CBQ must keep headers");
+    assert!(reader.header().has_qualities(), "CBQ must keep qualities");
+    assert_eq!(reader.num_records(), 2);
+
+    // CBQ -> FASTQ matches the FASTQ baseline byte-for-byte
+    let roundtrip = temp_dir.path().join("roundtrip.fastq");
+    cargo::cargo_bin_cmd!("deacon")
+        .args(["filter", "-a", "1", "-r", "0.0", "-t", "1"])
+        .arg(&bin_path)
+        .arg(&cbq_path)
+        .arg("--output")
+        .arg(&roundtrip)
+        .assert()
+        .success();
+    assert_eq!(
+        fs::read(&roundtrip).unwrap(),
+        fs::read(&baseline).unwrap(),
+        "CBQ round trip must match the FASTQ output"
+    );
+
+    // Summary sequence/base counts agree across formats
+    let s1: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&summary1).unwrap()).unwrap();
+    let s2: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&summary2).unwrap()).unwrap();
+    for field in ["seqs_in", "seqs_out", "bp_in", "bp_out"] {
+        assert_eq!(s1[field], s2[field], "summary field {field} differs");
+    }
+
+    // Paired: FASTQ -> one paired CBQ (2 native paired records)
+    let paired_cbq = temp_dir.path().join("paired.cbq");
+    cargo::cargo_bin_cmd!("deacon")
+        .args(["filter", "-a", "1", "-r", "0.0", "-t", "1"])
+        .arg(&bin_path)
+        .arg(&r1_path)
+        .arg(&r2_path)
+        .arg("--output")
+        .arg(&paired_cbq)
+        .assert()
+        .success();
+    let reader = binseq::cbq::MmapReader::new(&paired_cbq).unwrap();
+    assert!(reader.is_paired(), "paired FASTQ must produce a paired CBQ");
+    assert_eq!(reader.num_records(), 2);
+
+    // CBQ -> CBQ preserves pairing, headers, sequences, qualities
+    let cbq2 = temp_dir.path().join("paired2.cbq");
+    cargo::cargo_bin_cmd!("deacon")
+        .args(["filter", "-a", "1", "-r", "0.0", "-t", "1"])
+        .arg(&bin_path)
+        .arg(&paired_cbq)
+        .arg("--output")
+        .arg(&cbq2)
+        .assert()
+        .success();
+    let reader = binseq::cbq::MmapReader::new(&cbq2).unwrap();
+    assert!(reader.is_paired(), "CBQ -> CBQ must preserve pairing");
+    assert_eq!(reader.num_records(), 2);
+
+    // CBQ -> FASTQ matches the paired FASTQ -> FASTQ interleaved baseline
+    let paired_baseline = temp_dir.path().join("paired_baseline.fastq");
+    cargo::cargo_bin_cmd!("deacon")
+        .args(["filter", "-a", "1", "-r", "0.0", "-t", "1"])
+        .arg(&bin_path)
+        .arg(&r1_path)
+        .arg(&r2_path)
+        .arg("--output")
+        .arg(&paired_baseline)
+        .assert()
+        .success();
+    let paired_roundtrip = temp_dir.path().join("paired_roundtrip.fastq");
+    cargo::cargo_bin_cmd!("deacon")
+        .args(["filter", "-a", "1", "-r", "0.0", "-t", "1"])
+        .arg(&bin_path)
+        .arg(&cbq2)
+        .arg("--output")
+        .arg(&paired_roundtrip)
+        .assert()
+        .success();
+    assert_eq!(
+        fs::read(&paired_roundtrip).unwrap(),
+        fs::read(&paired_baseline).unwrap(),
+        "paired CBQ round trip must match the interleaved FASTQ output"
+    );
+
+    // --fasta creates a quality-free CBQ
+    let fasta_cbq = temp_dir.path().join("fasta.cbq");
+    cargo::cargo_bin_cmd!("deacon")
+        .args(["filter", "-a", "1", "-r", "0.0", "-t", "1", "--fasta"])
+        .arg(&bin_path)
+        .arg(&fastq_path)
+        .arg("--output")
+        .arg(&fasta_cbq)
+        .assert()
+        .success();
+    let reader = binseq::cbq::MmapReader::new(&fasta_cbq).unwrap();
+    assert!(
+        !reader.header().has_qualities(),
+        "--fasta must produce a quality-free CBQ"
+    );
+    assert_eq!(reader.num_records(), 2);
+
+    // Empty retained output is written as a structurally valid zero-record CBQ
+    let aaa_path = temp_dir.path().join("aaa.fasta");
+    let aaa_bin = temp_dir.path().join("aaa.bin");
+    create_test_fasta_aaa(&aaa_path);
+    build_index(&aaa_path, &aaa_bin);
+    let empty_cbq = temp_dir.path().join("empty.cbq");
+    cargo::cargo_bin_cmd!("deacon")
+        .args(["filter", "-t", "1"])
+        .arg(&aaa_bin)
+        .arg(&fastq_path)
+        .arg("--output")
+        .arg(&empty_cbq)
+        .assert()
+        .success();
+    let empty_bytes = fs::read(&empty_cbq).unwrap();
+    assert!(
+        empty_bytes.starts_with(b"CBQFILE"),
+        "empty retained output must be a CBQ file"
+    );
+    // binseq 0.9.4 cannot reopen zero-record CBQ files (upstream index-cast
+    // bug); deacon treats such inputs as valid empty inputs.
+    let header = binseq::cbq::FileHeader::from_bytes(&empty_bytes[..64]).unwrap();
+    assert!(
+        header.has_qualities(),
+        "empty CBQ must keep the writer quality flag"
+    );
+
+    // ... and it reads back as empty FASTX
+    let empty_out = temp_dir.path().join("empty_out.fastq");
+    cargo::cargo_bin_cmd!("deacon")
+        .args(["filter", "-a", "1", "-r", "0.0", "-t", "1"])
+        .arg(&bin_path)
+        .arg(&empty_cbq)
+        .arg("--output")
+        .arg(&empty_out)
+        .assert()
+        .success();
+    assert!(fs::read_to_string(&empty_out).unwrap().is_empty());
+
+    // Invalid CBQ argument combinations fail before output creation
+    let no_create = temp_dir.path().join("should_not_exist.cbq");
+
+    cargo::cargo_bin_cmd!("deacon")
+        .args(["filter", "-t", "1"])
+        .arg(&bin_path)
+        .arg(&cbq_path)
+        .arg(&r2_path) // CBQ input + INPUT2
+        .arg("--output")
+        .arg(&no_create)
+        .assert()
+        .failure();
+    assert!(
+        !no_create.exists(),
+        "CBQ input + INPUT2 must fail before output creation"
+    );
+
+    cargo::cargo_bin_cmd!("deacon")
+        .args(["filter", "--interleaved", "-t", "1"])
+        .arg(&bin_path)
+        .arg(&cbq_path) // CBQ input + --interleaved
+        .arg("--output")
+        .arg(&no_create)
+        .assert()
+        .failure();
+    assert!(
+        !no_create.exists(),
+        "CBQ input + --interleaved must fail before output creation"
+    );
+
+    cargo::cargo_bin_cmd!("deacon")
+        .args(["filter", "-t", "1"])
+        .arg(&bin_path)
+        .arg(&fastq_path)
+        .arg("--output")
+        .arg(&no_create)
+        .arg("--output2")
+        .arg(temp_dir.path().join("x.fastq")) // CBQ output + OUTPUT2
+        .assert()
+        .failure();
+    assert!(
+        !no_create.exists(),
+        "CBQ output + OUTPUT2 must fail before output creation"
+    );
+
+    let gz_cbq = temp_dir.path().join("bad.cbq.gz");
+    cargo::cargo_bin_cmd!("deacon")
+        .args(["filter", "-t", "1"])
+        .arg(&bin_path)
+        .arg(&fastq_path)
+        .arg("--output")
+        .arg(&gz_cbq) // compressed CBQ output
+        .assert()
+        .failure();
+    assert!(
+        !gz_cbq.exists(),
+        ".cbq.gz output must fail before output creation"
+    );
+
+    // --check-pairs + headerless CBQ input
+    let headerless = temp_dir.path().join("headerless.cbq");
+    write_headerless_paired_cbq(&headerless);
+    cargo::cargo_bin_cmd!("deacon")
+        .args(["filter", "--check-pairs", "-t", "1"])
+        .arg(&bin_path)
+        .arg(&headerless)
+        .arg("--output")
+        .arg(&no_create)
+        .assert()
+        .failure();
+    assert!(
+        !no_create.exists(),
+        "--check-pairs + headerless CBQ must fail before output creation"
+    );
+}


### PR DESCRIPTION
This PR includes the necessary implemenation for`deacon filter` to accept CBQ (BINSEQ) input, detected automatically, and writes CBQ when the output path ends in `.cbq`. Benchmark output is consistent between any format combination.

Main change against #31 is only CBQ support, dropping VBQ/BQ.

## Benchmark: FASTQ vs CBQ, deacon filter 0.16.0

Input: 500k real viral reads (~4 kb each, 1.9 GB) from rsviruses17900 (Zenodo), filtered against an index built from the 17,900 virus contigs (rsviruses17900.fa.gz); keep-all thresholds (-a 1 -r 0), -t 8, 16-core box; hyperfine min/median of 3 + one /usr/bin/time -v pass for peak RSS.

| arm | min (s) | median (s) | peak RSS (MB) |
|-----|---------|------------|---------------|
| fq->fq | 2.95 | 3.05 | 662 |
| fq->fq.gz | 4.02 | 4.06 | 681 |
| fq->cbq | 2.86 | 2.91 | 674 |
| fq.gz->fq.gz | 4.26 | 4.32 | 687 |
| fq.gz->cbq | 3.08 | 3.09 | 671 |
| cbq->fq | 2.98 | 3.01 | 813 |
| cbq->fq.gz | 4.01 | 4.03 | 830 |
| cbq->cbq | 2.98 | 3.06 | 840 |
| fq(r1+r2)->fq | 3.27 | 3.46 | 663 |
| fq(r1+r2)->cbq | 3.05 | 3.16 | 675 |
| cbq->fq (paired) | 3.31 | 3.36 | 814 |
| cbq->cbq (paired) | 2.96 | 2.98 | 841 |

Findings
- CBQ output is free: fq->cbq (2.86 s) beats plain fq->fq (2.95 s) + fq->fq.gz (4.02 s); gz output is the slowest arm by ~40%.
- CBQ beats gzip on size: 197.5 MB vs 330.1 MB (40% smaller) on this data; 10× smaller than plain fq.
- CBQ input costs ~150 MB RSS (mmap + embedded index: 662→813 MB); negligible on speed.
- gz input adds ~0.2 s regardless of output format. CBQ roundtrips preserve counts exactly (seqs_out identical within each input group).

*Paired reads were derived by half-splitting real reads.